### PR TITLE
Always register the erb template handler

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -18,9 +18,7 @@ module ReActionView
 
     initializer "reactionview.configure_erb_handler" do
       ActiveSupport.on_load(:action_view) do
-        if ReActionView.config.intercept_erb
-          ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::Herb
-        end
+        ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::Herb
       end
     end
   end


### PR DESCRIPTION
See #1 

This code is ran before the reactionview.rb initializer in the user's app can be run, therefore the erb handler is never registered. There is already a check on the `intercept_erb` config inside the handler, so it's safe to register it at all times.

Let me know if you prefer a different approach at solving this issue 