### PR TITLE
Register template handler after app initializers have set config

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -16,7 +16,7 @@ module ReActionView
       end
     end
 
-    initializer "reactionview.configure_erb_handler" do
+    config.after_initialize do
       ActiveSupport.on_load(:action_view) do
         if ReActionView.config.intercept_erb
           ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::Herb


### PR DESCRIPTION
This waits to register the erb handler until after the initializers have run and had a chance to set the configuration.

Fixes #1 and alternative to #2