### PR TITLE
Add ReActionView assets to `app.config.assets.precompile`

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -12,7 +12,7 @@ module ReActionView
     PRECOMPILE_ASSETS = %w[
       reactionview-dev-tools.esm.js
       reactionview-dev-tools.umd.js
-    ]
+    ].freeze
 
     initializer "reactionview.assets" do |app|
       if ReActionView.config.development? && app.config.respond_to?(:assets)

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -2,11 +2,24 @@
 
 module ReActionView
   class Railtie < Rails::Railtie
+    # If you don't want to precompile ReActionView's assets (eg. because you're using propshaft),
+    # you can do this in an initializer:
+    #
+    # config.after_initialize do
+    #   config.assets.precompile -= ReActionView::Railtie::PRECOMPILE_ASSETS
+    # end
+    #
+    PRECOMPILE_ASSETS = %w[
+      reactionview-dev-tools.esm.js
+      reactionview-dev-tools.umd.js
+    ]
+
     initializer "reactionview.assets" do |app|
       if ReActionView.config.development? && app.config.respond_to?(:assets)
         gem_root = Gem::Specification.find_by_name("reactionview").gem_dir
 
         app.config.assets.paths << File.join(gem_root, "app", "assets", "javascripts")
+        app.config.assets.precompile += PRECOMPILE_ASSETS
       end
     end
 


### PR DESCRIPTION
This pull requests adds the ReActionView assets to the `app.config.assets.precompile` config so that Sprockets doesn't raise this error in development about the asset not being declared for precompilation in production.

```
Sprockets::Rails::Helper::AssetNotPrecompiledError at /users/sign_in

Asset `reactionview-dev-tools.umd.js` was not declared to be precompiled in production.
Declare links to your assets in `app/assets/config/manifest.js`.
  //= link reactionview-dev-tools.umd.js
and restart your server
```


Resolves #8 