### PR TITLE
Call default ERB handler for non-html formats

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -31,7 +31,7 @@ module ReActionView
 
     config.after_initialize do
       ActiveSupport.on_load(:action_view) do
-        ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::Herb if ReActionView.config.intercept_erb
+        ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::ERB if ReActionView.config.intercept_erb
       end
     end
   end

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -9,8 +9,6 @@ module ReActionView
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
 
         def call(template, source)
-          return ActionView::Template::Handlers::ERB.call(template, source) if template.format != :html
-
           config = {
             filename: template.identifier,
             project_path: Rails.root.to_s,

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -5,6 +5,7 @@ require_relative "../../test_helper"
 class HerbTemplateHandlerTest < Minitest::Test
   def setup
     ReActionView.config.debug_mode = false
+    ReActionView.config.intercept_erb = true
 
     lookup_context = ActionView::LookupContext.new([])
     @view_context = ActionView::Base.with_empty_template_cache.new(lookup_context, {}, nil)
@@ -17,7 +18,7 @@ class HerbTemplateHandlerTest < Minitest::Test
     template = ActionView::Template.new(
       template_source,
       "test_template",
-      ReActionView::Template::Handlers::Herb,
+      ReActionView::Template::Handlers::ERB,
       virtual_path: "test",
       format: :html,
       locals: []
@@ -34,7 +35,7 @@ class HerbTemplateHandlerTest < Minitest::Test
     template = ActionView::Template.new(
       template_source,
       "test_template",
-      ReActionView::Template::Handlers::Herb,
+      ReActionView::Template::Handlers::ERB,
       virtual_path: "test",
       format: :text,
       locals: []


### PR DESCRIPTION
Hey!

When `ReActionView.config.intercept_erb = true` is set and overrides the :erb handler, it causes _all_ ERB templates to run through herb.

I have Redcarpet installed for markdown, and the unclosed "tag" here caused it to silently fail in a `.md.erb` template:

````
```
curl <%= events_url %> -u <API_KEY>:
```
````

This adds a simple check for non-html formats and calls the original ERB implementation.

Thanks :)