### PR TITLE
Do not enable debug tools for lib templates

### DIFF
--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -11,7 +11,7 @@ module ReActionView
         def call(template, source)
           visitors = []
 
-          if ::ReActionView.config.debug_mode_enabled && local_template?(template)?
+          if ::ReActionView.config.debug_mode_enabled? && local_template?(template)
             visitors << ::Herb::Engine::DebugVisitor.new(
               file_path: template.identifier,
               project_path: Rails.root.to_s
@@ -38,6 +38,8 @@ module ReActionView
         end
 
         def local_template?(template)
+          return true unless template.respond_to?(:identifier) && template.identifier
+
           template.identifier.start_with?("#{Rails.root}/app/views")
         end
 


### PR DESCRIPTION
## Problem statement 

When using `reactionview` with the `intercept_erb` and `debug` options, one can get warnings for templates that are outside one's control. 

Here's an example with the [Avo ](https://github.com/avo-hq/avo) dashboard in one of my apps: 

<img width="2726" height="1776" alt="CleanShot 2025-10-10 at 15 37 01@2x" src="https://github.com/user-attachments/assets/0b4905ce-c338-4254-af1d-e84b06764418" />

The problem has also been described in https://github.com/marcoroth/reactionview/issues/43

## Proposed solution

The proposed change here only allows debug for "local" templates, i.e. templates rendered from the main app `app/views` directory. 

## Potential shortcomings 

The solution proposed only works for templates inside `"#{Rails.root}/app/views"`. 
It means that should an app use local engines, the engine templates will not benefit from ReActionView debug tools. 

One potential solution would be to add a new configuration item that would basically be an allow-list for other template paths within the app. 

resolves https://github.com/marcoroth/reactionview/issues/43

