### PR TITLE
Fix recursive `DebugVisitor` that could cause app to crash

### DIFF
--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -9,20 +9,22 @@ module ReActionView
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
 
         def call(template, source)
+          visitors = []
+
+          if ::ReActionView.config.debug_mode_enabled?
+            visitors << ::Herb::Engine::DebugVisitor.new(
+              file_path: template.identifier,
+              project_path: Rails.root.to_s
+            )
+          end
+
           config = {
             filename: template.identifier,
             project_path: Rails.root.to_s,
             validation_mode: :overlay,
             content_for_head: reactionview_dev_tools_markup(template),
-            visitors: ReActionView.config.transform_visitors,
+            visitors: visitors + ReActionView.config.transform_visitors,
           }
-
-          if ::ReActionView.config.debug_mode_enabled?
-            config[:visitors] << ::Herb::Engine::DebugVisitor.new(
-              file_path: template.identifier,
-              project_path: Rails.root.to_s
-            )
-          end
 
           erb_implementation.new(source, config).src
         end


### PR DESCRIPTION
This pull request fixes a bug in the way ReActionView calls the `Herb::DebugVisitor` when `debug_mode` is enabled.

For every time the `ReActionView::Template::Handlers::Herb` handler compiled a template it would shuffle one more debug visitor into the global shared `ReActionView.config.transform_visitors` config, thus leading to add multiple `Herb::DebugVisitor` and therefore recursively rendering more and more debug `<span>`s:


<img width="2624" height="1292" alt="image" src="https://github.com/user-attachments/assets/9970f417-1385-4d43-a826-c9fc2e7b7822" />

/cc @adrianthedev @miharekar @tcannonfodder (thanks for reporting!)

Also thanks to @timkaechele for helping with debugging!