### PR TITLE
Add support for packs and internal engines

### DIFF
--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -40,7 +40,9 @@ module ReActionView
         def local_template?(template)
           return true unless template.respond_to?(:identifier) && template.identifier
 
-          template.identifier.start_with?("#{Rails.root}/app/views")
+          ActionController::Base.view_paths
+                                .select { |view_path| view_path.path.start_with?(Rails.root.to_s) }
+                                .any? { |view_path| template.identifier.start_with?(view_path.path) }
         end
 
         def active_support_editor


### PR DESCRIPTION
When using packs or internal engines, the template paths may not be nested directly under the Rails root `app/views` directory.

For example, the default for [packs-rails](https://github.com/rubyatscale/packs-rails) is to use a `packs` directory under the Rails root, so the layout could be in a directory like `#{Rails.root}/packs/pack_name/app/views`