### PR TITLE
Update to Herb v0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -107,12 +107,12 @@ GEM
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -63,12 +63,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -63,12 +63,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -63,12 +63,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -63,12 +63,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -62,12 +62,12 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -46,7 +46,7 @@ PATH
   specs:
     reactionview (0.1.6)
       actionview (>= 7.0)
-      herb (>= 0.7.5, < 1.0.0)
+      herb (>= 0.8.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -76,12 +76,12 @@ GEM
     drb (2.2.3)
     erb (5.1.1)
     erubi (1.13.1)
-    herb (0.7.5)
-    herb (0.7.5-aarch64-linux-musl)
-    herb (0.7.5-arm64-darwin)
-    herb (0.7.5-x86_64-darwin)
-    herb (0.7.5-x86_64-linux-gnu)
-    herb (0.7.5-x86_64-linux-musl)
+    herb (0.8.0)
+    herb (0.8.0-aarch64-linux-gnu)
+    herb (0.8.0-aarch64-linux-musl)
+    herb (0.8.0-arm-linux-gnu)
+    herb (0.8.0-arm-linux-musl)
+    herb (0.8.0-x86_64-linux-musl)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/dev-tools": "0.7.5"
+    "@herb-tools/dev-tools": "0.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/reactionview.gemspec
+++ b/reactionview.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionview", ">= 7.0"
-  spec.add_dependency "herb", ">= 0.7.5", "< 1.0.0"
+  spec.add_dependency "herb", ">= 0.8.0", "< 1.0.0"
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,17 +180,17 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@herb-tools/core@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.7.5.tgz#f433cdc98fcd3062af740a50c27ab8efa826e08c"
-  integrity sha512-6VJBVAKMJzZQQfM03YS6iYsw7HokDQpNSOdjFx/gYNpU2cFGoq9KzzYevLwALnVXI8gfIPyNKdim8/vScj/02w==
+"@herb-tools/core@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.8.0.tgz#5525e5b7b173ce8148641d2fab2fb2800bd2fe2d"
+  integrity sha512-f7Ofua1X9dreWuoiD144jKxYXGYwghQjy/+TjMQjqRgpBkPMrHS8wWBetMKMX1mCIzeT1ZVKUTlBUyE2SrW6uw==
 
-"@herb-tools/dev-tools@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@herb-tools/dev-tools/-/dev-tools-0.7.5.tgz#985c4236db7bac01b375006e0697c8a0ce73d998"
-  integrity sha512-UW2Cb3DDbU7awhZtJcxhN4ptic0O0uuKd/eeV2tSA0WASPOSRYeW5vBZWt0fXBqZMmpwju8Jgg3CYF8RXNBskQ==
+"@herb-tools/dev-tools@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@herb-tools/dev-tools/-/dev-tools-0.8.0.tgz#50122689270e3976766c73e905af9d0c24f237c7"
+  integrity sha512-XIpi/53XuWiJkBbOZZ1lWkpxUiUoiNzVN9/bmMOsU8nn7yBK613W8nFEd4kg6FGFvNwXm1d2LDi5D3VHu6GmsA==
   dependencies:
-    "@herb-tools/core" "0.7.5"
+    "@herb-tools/core" "0.8.0"
 
 "@iconify-json/logos@^1.2.4":
   version "1.2.9"


### PR DESCRIPTION
[Herb v0.8](https://github.com/marcoroth/herb/releases/tag/v0.8.0) just released. This pull request bumps the `herb` dependency to `>= 0.8.0`.

Enables #53