### PR TITLE
Use `Rails.root` to determine if template is local

### DIFF
--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -40,9 +40,7 @@ module ReActionView
         def local_template?(template)
           return true unless template.respond_to?(:identifier) && template.identifier
 
-          ActionController::Base.view_paths
-                                .select { |view_path| view_path.path.start_with?(Rails.root.to_s) }
-                                .any? { |view_path| template.identifier.start_with?(view_path.path) }
+          template.identifier.start_with?(Rails.root.to_s)
         end
 
         def active_support_editor


### PR DESCRIPTION
Follow up on #56

The approach we used in #56 also wasn't quite right, as it wasn't detecting templates in `#{Rails.root}/app/components` since they weren't part of the `view_parts`.

Instead, let's just consider everything a local template if it's within `Rails.root`, which should work for internal engines, packwerk etc.

Related https://github.com/marcoroth/herb/issues/1088
Related https://github.com/marcoroth/herb/pull/1132