### PR TITLE
Fix ERB expression compilation when code contains a heredoc

### DIFF
--- a/lib/reactionview/template/handlers/herb/herb.rb
+++ b/lib/reactionview/template/handlers/herb/herb.rb
@@ -66,7 +66,7 @@ module ReActionView
                       end
 
               if wrap_parentheses
-                @src << "(" << code << ")"
+                @src << "(" << code << "\n)"
               else
                 @src << " " << code
               end

--- a/test/snapshots/herb/template_handler_test/test_0003_template_with_expression_compiled_40e3b949384b06dd58f462a17aa0827b.txt
+++ b/test/snapshots/herb/template_handler_test/test_0003_template_with_expression_compiled_40e3b949384b06dd58f462a17aa0827b.txt
@@ -1,2 +1,3 @@
- @output_buffer.safe_append='<h1>Hello '.freeze; @output_buffer.append=(@name); @output_buffer.safe_append='</h1>'.freeze;
+ @output_buffer.safe_append='<h1>Hello '.freeze; @output_buffer.append=(@name
+); @output_buffer.safe_append='</h1>'.freeze;
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0005_raw_and_regular_output_compiled_ce838ee50a8780e359b0426fe5b6bfb4.txt
+++ b/test/snapshots/herb/template_handler_test/test_0005_raw_and_regular_output_compiled_ce838ee50a8780e359b0426fe5b6bfb4.txt
@@ -1,2 +1,4 @@
- @output_buffer.append=(@html); @output_buffer.append=(raw @safe_html);
+ @output_buffer.append=(@html
+); @output_buffer.append=(raw @safe_html
+);
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0006_template_with_newlines_compiled_ca45577d00c738a24540dfeb3f7885ef.txt
+++ b/test/snapshots/herb/template_handler_test/test_0006_template_with_newlines_compiled_ca45577d00c738a24540dfeb3f7885ef.txt
@@ -1,4 +1,5 @@
  @output_buffer.safe_append='<div>
-'.freeze; @output_buffer.append=(@content); @output_buffer.safe_append='
+'.freeze; @output_buffer.append=(@content
+); @output_buffer.safe_append='
 </div>'.freeze;
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0007_multiple_expressions_compiled_082a93002fba858b87a75785cd88a2b7.txt
+++ b/test/snapshots/herb/template_handler_test/test_0007_multiple_expressions_compiled_082a93002fba858b87a75785cd88a2b7.txt
@@ -1,2 +1,4 @@
- @output_buffer.safe_append='<h1>Hello '.freeze; @output_buffer.append=(@name); @output_buffer.safe_append='!</h1><p>'.freeze; @output_buffer.append=(@message); @output_buffer.safe_append='</p>'.freeze;
+ @output_buffer.safe_append='<h1>Hello '.freeze; @output_buffer.append=(@name
+); @output_buffer.safe_append='!</h1><p>'.freeze; @output_buffer.append=(@message
+); @output_buffer.safe_append='</p>'.freeze;
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0008_xss_protection_compiled_8fc34c93947921e6cf438e5adfc691d7.txt
+++ b/test/snapshots/herb/template_handler_test/test_0008_xss_protection_compiled_8fc34c93947921e6cf438e5adfc691d7.txt
@@ -1,2 +1,3 @@
- @output_buffer.safe_append='<div>'.freeze; @output_buffer.append=(@unsafe_content); @output_buffer.safe_append='</div>'.freeze;
+ @output_buffer.safe_append='<div>'.freeze; @output_buffer.append=(@unsafe_content
+); @output_buffer.safe_append='</div>'.freeze;
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0009_content_tag_helper_compiled_9d7872dac3cef10a2a63f61404a4b051.txt
+++ b/test/snapshots/herb/template_handler_test/test_0009_content_tag_helper_compiled_9d7872dac3cef10a2a63f61404a4b051.txt
@@ -1,2 +1,3 @@
- @output_buffer.append=(content_tag :div, "Hello", class: "greeting");
+ @output_buffer.append=(content_tag :div, "Hello", class: "greeting"
+);
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0010_user_card_with_conditional_and_link_to_compiled_351531c91827e79a1a9ab2f324c18ce9.txt
+++ b/test/snapshots/herb/template_handler_test/test_0010_user_card_with_conditional_and_link_to_compiled_351531c91827e79a1a9ab2f324c18ce9.txt
@@ -1,5 +1,6 @@
  @output_buffer.safe_append='<div class="user-card">
-  <h2>'.freeze; @output_buffer.append=(@user[:name]); @output_buffer.safe_append='</h2>
+  <h2>'.freeze; @output_buffer.append=(@user[:name]
+); @output_buffer.safe_append='</h2>
 '.freeze;   if @user[:verified] 
  @output_buffer.safe_append='    <span class="badge">Verified</span>
 '.freeze;   end 

--- a/test/snapshots/herb/template_handler_test/test_0011_complex_layout_with_helpers_compiled_3a9949064612857244b6b8987a2b6dc3.txt
+++ b/test/snapshots/herb/template_handler_test/test_0011_complex_layout_with_helpers_compiled_3a9949064612857244b6b8987a2b6dc3.txt
@@ -1,13 +1,16 @@
  @output_buffer.safe_append='<div class="container py-8">
-  <h1 class="title">'.freeze; @output_buffer.append=(title "Events by Country"); @output_buffer.safe_append='</h1>
+  <h1 class="title">'.freeze; @output_buffer.append=(title "Events by Country"
+); @output_buffer.safe_append='</h1>
 
-  '.freeze; @output_buffer.append=(ui_button "View all cities", url: cities_path, kind: :secondary); @output_buffer.safe_append='
+  '.freeze; @output_buffer.append=(ui_button "View all cities", url: cities_path, kind: :secondary
+); @output_buffer.safe_append='
 
 '.freeze;   if @show_countries 
  @output_buffer.safe_append='    <h2>Countries</h2>
     '.freeze; @output_buffer.append= link_to country_path("switzerland"), id: "country-ch", class: "event-item" do; @output_buffer.safe_append='
       <span class="event-name">🇨🇭 Switzerland</span>
-      '.freeze; @output_buffer.append=(ui_badge(5, kind: :secondary, class: "event-count")); @output_buffer.safe_append='
+      '.freeze; @output_buffer.append=(ui_badge(5, kind: :secondary, class: "event-count")
+); @output_buffer.safe_append='
 '.freeze;     end 
    end 
  @output_buffer.safe_append='</div>

--- a/test/snapshots/herb/template_handler_test/test_0029_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_compiled_ffc55de9e7891578a81f0a2b0c1346a5.txt
+++ b/test/snapshots/herb/template_handler_test/test_0029_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_compiled_ffc55de9e7891578a81f0a2b0c1346a5.txt
@@ -1,0 +1,8 @@
+ @output_buffer.append=(method_call <<~GRAPHQL, variables
+  query {
+    field
+  }
+GRAPHQL
+);
+ @output_buffer.safe_append='
+'.freeze;@output_buffer

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -342,4 +342,17 @@ class Herb::TemplateHandlerTest < Minitest::Spec
     assert_compiled_snapshot(template)
     assert_evaluated_snapshot(template, ivars: { config: { key: "value" } })
   end
+
+  test "heredoc with trailing arguments compiles to valid Ruby" do
+    template = <<~ERB
+      <%= method_call <<~GRAPHQL, variables
+        query {
+          field
+        }
+      GRAPHQL
+      %>
+    ERB
+
+    assert_compiled_snapshot(template)
+  end
 end


### PR DESCRIPTION
I attempted to use Reactionview in Buildkite's Rails monolith and found a blocking issue related to Heredocs. 

When an ERB output tag wraps code in parentheses and that code contains a heredoc:

```ruby
some_method, <<~A_HEREDOC, some_methods_attributes
  contents
  of
  the heredoc
A HEREDOC
```
the closing parenthesis must appear on its own line after the heredoc terminator. Without this, the compiled Ruby is syntactically invalid.

This is my first time diving into herb and reactionview so I relied quite a bit on AI for this as I get more comfortable. However, I reviewed the code thoroughly and tested it in CI in Buildkite where I was able to reduce failed specs from ~700 to ~60.

This is a sibling commit of https://github.com/marcoroth/herb/pull/1206

