### PR TITLE
Add support for caching in build step

### DIFF
--- a/lib/reactionview.rb
+++ b/lib/reactionview.rb
@@ -22,6 +22,7 @@ require_relative "reactionview/template/handlers/erb"
 require_relative "reactionview/template/handlers/herb"
 require_relative "reactionview/template/handlers/herb/herb"
 
+require_relative "reactionview/log_subscriber"
 require_relative "reactionview/railtie" if defined?(Rails::Railtie)
 
 module ReActionView

--- a/lib/reactionview.rb
+++ b/lib/reactionview.rb
@@ -2,6 +2,7 @@
 
 require_relative "reactionview/version"
 require_relative "reactionview/config"
+require_relative "reactionview/cache"
 
 # require_relative "reactionview/validation_error"
 # require_relative "reactionview/syntax_error_handler"

--- a/lib/reactionview/cache.rb
+++ b/lib/reactionview/cache.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "tempfile"
+
+module ReActionView
+  class Cache
+    attr_reader :directory
+
+    def initialize(directory)
+      @directory = directory
+      @mem = {}
+    end
+
+    def fetch(key)
+      mem_hit = @mem[key]
+      return mem_hit if mem_hit
+
+      path = cache_path(key)
+      return nil unless File.exist?(path)
+
+      src = File.read(path)
+      @mem[key] = src
+      src
+    rescue Errno::ENOENT, Errno::EACCES
+      nil
+    end
+
+    def store(key, compiled_src)
+      FileUtils.mkdir_p(@directory) unless Dir.exist?(@directory)
+
+      path = cache_path(key)
+
+      tmp = Tempfile.new(["reactionview_cache_", ".rb"], @directory)
+      begin
+        tmp.write(compiled_src)
+        tmp.close
+        File.rename(tmp.path, path)
+      rescue StandardError
+        tmp.close!
+      end
+
+      @mem[key] = compiled_src
+    end
+
+    def key_for(source, properties = {})
+      fingerprint = {
+        herb_version: defined?(::Herb::VERSION) ? ::Herb::VERSION : "unknown",
+        reactionview_version: ReActionView::VERSION,
+        ruby_version: RUBY_VERSION,
+        validation_mode: properties.fetch(:validation_mode, :raise).to_s,
+        bufvar: properties[:bufvar] || "@output_buffer",
+        freeze_template_literals: properties.fetch(:freeze_template_literals, true),
+        escapefunc: properties.fetch(:escapefunc, ""),
+        filename: properties[:filename],
+      }
+
+      data = source + "\0" + JSON.generate(fingerprint.sort.to_h)
+      Digest::SHA256.hexdigest(data)
+    end
+
+    def clear!
+      @mem.clear
+      FileUtils.rm_rf(@directory)
+    end
+
+    def size
+      return 0 unless Dir.exist?(@directory)
+
+      Dir.glob(File.join(@directory, "*.rb")).length
+    end
+
+    private
+
+    def cache_path(key)
+      File.join(@directory, "#{key}.rb")
+    end
+  end
+end

--- a/lib/reactionview/cache.rb
+++ b/lib/reactionview/cache.rb
@@ -29,7 +29,7 @@ module ReActionView
     end
 
     def store(key, compiled_src)
-      FileUtils.mkdir_p(@directory) unless Dir.exist?(@directory)
+      FileUtils.mkdir_p(@directory)
 
       path = cache_path(key)
 
@@ -56,7 +56,7 @@ module ReActionView
         escapefunc: properties.fetch(:escapefunc, ""),
       }
 
-      data = source + "\0" + JSON.generate(fingerprint.sort.to_h)
+      data = "#{source}\0#{JSON.generate(fingerprint.sort.to_h)}"
       Digest::SHA256.hexdigest(data)
     end
 

--- a/lib/reactionview/cache.rb
+++ b/lib/reactionview/cache.rb
@@ -54,7 +54,6 @@ module ReActionView
         bufvar: properties[:bufvar] || "@output_buffer",
         freeze_template_literals: properties.fetch(:freeze_template_literals, true),
         escapefunc: properties.fetch(:escapefunc, ""),
-        filename: properties[:filename],
       }
 
       data = source + "\0" + JSON.generate(fingerprint.sort.to_h)

--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -5,12 +5,16 @@ module ReActionView
     attr_accessor :intercept_erb
     attr_accessor :debug_mode
     attr_accessor :transform_visitors
+    attr_accessor :cache
+    attr_accessor :cache_directory
     attr_writer :validation_mode
 
     def initialize
       @intercept_erb = false
       @debug_mode = nil
       @transform_visitors = []
+      @cache = false
+      @cache_directory = "tmp/reactionview/cache"
     end
 
     def validation_mode
@@ -40,6 +44,10 @@ module ReActionView
 
   def self.config
     @config ||= Config.new
+  end
+
+  def self.cache
+    @cache ||= Cache.new(config.cache_directory)
   end
 
   def self.configure

--- a/lib/reactionview/log_subscriber.rb
+++ b/lib/reactionview/log_subscriber.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ReActionView
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def cache_miss(event)
+      info "[ReActionView] Cache miss for #{event.payload[:identifier]}"
+    end
+  end
+end

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -18,6 +18,10 @@ module ReActionView
       load "tasks/reactionview.rake"
     end
 
+    initializer "reactionview.log_subscriber" do
+      ReActionView::LogSubscriber.attach_to(:reactionview)
+    end
+
     initializer "reactionview.assets" do |app|
       if ReActionView.config.development? && app.config.respond_to?(:assets)
         gem_root = Gem::Specification.find_by_name("reactionview").gem_dir

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -14,6 +14,10 @@ module ReActionView
       reactionview-dev-tools.umd.js
     ].freeze
 
+    rake_tasks do
+      load "tasks/reactionview.rake"
+    end
+
     initializer "reactionview.assets" do |app|
       if ReActionView.config.development? && app.config.respond_to?(:assets)
         gem_root = Gem::Specification.find_by_name("reactionview").gem_dir

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -24,7 +24,7 @@ module ReActionView
             if cached
               return cached
             else
-              puts "[ReActionView] Cache miss for #{template.identifier}"
+              ActiveSupport::Notifications.instrument("cache_miss.reactionview", identifier: template.identifier)
             end
           end
 

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -12,7 +12,6 @@ module ReActionView
           # Check cache before compiling (only for non-debug, when cache is enabled)
           if ::ReActionView.config.cache && !::ReActionView.config.debug_mode_enabled?
             cache_properties = {
-              filename: template.identifier,
               validation_mode: ReActionView.config.validation_mode,
               bufvar: "@output_buffer",
               freeze_template_literals: !::ActionView::Template.frozen_string_literal,

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -9,6 +9,25 @@ module ReActionView
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
 
         def call(template, source)
+          # Check cache before compiling (only for non-debug, when cache is enabled)
+          if ::ReActionView.config.cache && !::ReActionView.config.debug_mode_enabled?
+            cache_properties = {
+              filename: template.identifier,
+              validation_mode: ReActionView.config.validation_mode,
+              bufvar: "@output_buffer",
+              freeze_template_literals: !::ActionView::Template.frozen_string_literal,
+              escapefunc: "",
+            }
+
+            cache_key = ::ReActionView.cache.key_for(source, cache_properties)
+            cached = ::ReActionView.cache.fetch(cache_key)
+            if cached
+              return cached
+            else
+              puts "[ReActionView] Cache miss for #{template.identifier}"
+            end
+          end
+
           visitors = []
 
           if ::ReActionView.config.debug_mode_enabled? && local_template?(template)

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -8,7 +8,7 @@ module ReActionView
 
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
 
-        def call(template, source)
+        def call(template, source) # rubocop:disable Metrics/MethodLength
           # Check cache before compiling (only for non-debug, when cache is enabled)
           if ::ReActionView.config.cache && !::ReActionView.config.debug_mode_enabled?
             cache_properties = {
@@ -20,11 +20,9 @@ module ReActionView
 
             cache_key = ::ReActionView.cache.key_for(source, cache_properties)
             cached = ::ReActionView.cache.fetch(cache_key)
-            if cached
-              return cached
-            else
-              ActiveSupport::Notifications.instrument("cache_miss.reactionview", identifier: template.identifier)
-            end
+            return cached if cached
+
+            ActiveSupport::Notifications.instrument("cache_miss.reactionview", identifier: template.identifier)
           end
 
           visitors = []

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -8,17 +8,19 @@ module ReActionView
 
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
 
-        def call(template, source) # rubocop:disable Metrics/MethodLength
+        def self.cache_properties
+          {
+            validation_mode: ReActionView.config.validation_mode,
+            bufvar: erb_implementation::DEFAULT_BUFVAR,
+            freeze_template_literals: erb_implementation.freeze_template_literals_default?,
+            escapefunc: erb_implementation::DEFAULT_ESCAPEFUNC,
+          }
+        end
+
+        def call(template, source)
           # Check cache before compiling (only for non-debug, when cache is enabled)
           if ::ReActionView.config.cache && !::ReActionView.config.debug_mode_enabled?
-            cache_properties = {
-              validation_mode: ReActionView.config.validation_mode,
-              bufvar: "@output_buffer",
-              freeze_template_literals: !::ActionView::Template.frozen_string_literal,
-              escapefunc: "",
-            }
-
-            cache_key = ::ReActionView.cache.key_for(source, cache_properties)
+            cache_key = ::ReActionView.cache.key_for(source, self.class.cache_properties)
             cached = ::ReActionView.cache.fetch(cache_key)
             return cached if cached
 

--- a/lib/reactionview/template/handlers/herb/herb.rb
+++ b/lib/reactionview/template/handlers/herb/herb.rb
@@ -7,21 +7,28 @@ module ReActionView
     module Handlers
       class Herb
         class Herb < ::Herb::Engine
+          DEFAULT_BUFVAR = "@output_buffer"
+          DEFAULT_ESCAPEFUNC = ""
+
+          def self.freeze_template_literals_default?
+            !::ActionView::Template.frozen_string_literal
+          end
+
           def initialize(input, properties = {})
             @newline_pending = 0
 
             # Dup properties so that we don't modify argument
             properties = properties.to_h
 
-            properties[:bufvar]     ||= "@output_buffer"
+            properties[:bufvar]     ||= DEFAULT_BUFVAR
             properties[:preamble]   ||= ""
             properties[:postamble]  ||= properties[:bufvar].to_s
 
             # Tell Herb whether the template will be compiled with `frozen_string_literal: true`
-            properties[:freeze_template_literals] = !::ActionView::Template.frozen_string_literal
+            properties[:freeze_template_literals] = self.class.freeze_template_literals_default?
 
             # Disable all Herb escape functions - let ActionView::OutputBuffer handle escaping
-            properties[:escapefunc] = ""
+            properties[:escapefunc] = DEFAULT_ESCAPEFUNC
             properties[:attrfunc] = nil
             properties[:jsfunc] = nil
             properties[:cssfunc] = nil

--- a/lib/tasks/reactionview.rake
+++ b/lib/tasks/reactionview.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-namespace :reactionview do
+namespace :reactionview do # rubocop:disable Metrics/BlockLength
   desc "Precompile all HTML ERB and Herb templates to the ReActionView cache"
-  task precompile: :environment do
+  task precompile: :environment do # rubocop:disable Metrics/BlockLength
     require "reactionview/template/handlers/herb/herb"
 
     cache = ReActionView.cache
@@ -56,7 +56,7 @@ namespace :reactionview do
     puts "Precompiled #{compiled} templates in #{format("%.2f", elapsed)}s"
     puts "  Cache directory: #{cache.directory}"
     puts "  Cache entries: #{cache.size}"
-    puts "  Errors: #{errors}" if errors > 0
+    puts "  Errors: #{errors}" if errors.positive?
   end
 
   namespace :cache do

--- a/lib/tasks/reactionview.rake
+++ b/lib/tasks/reactionview.rake
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+namespace :reactionview do
+  desc "Precompile all HTML ERB and Herb templates to the ReActionView cache"
+  task precompile: :environment do
+    require "reactionview/template/handlers/herb/herb"
+
+    cache = ReActionView.cache
+    config = ReActionView.config
+
+    herb_config = Herb.configuration
+    files = herb_config.find_files(Rails.root.to_s)
+
+    if files.empty?
+      puts "No template files found."
+      exit(0)
+    end
+
+    compiled = 0
+    errors = 0
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    files.each do |file|
+      source = File.read(file)
+
+      properties = {
+        filename: file,
+        project_path: Rails.root.to_s,
+        validation_mode: config.validation_mode,
+        content_for_head: nil,
+        visitors: config.transform_visitors,
+      }
+
+      cache_properties = {
+        filename: file,
+        validation_mode: config.validation_mode,
+        bufvar: "@output_buffer",
+        freeze_template_literals: !ActionView::Template.frozen_string_literal,
+        escapefunc: "",
+      }
+
+      cache_key = cache.key_for(source, cache_properties)
+
+      begin
+        compiled_src = ReActionView::Template::Handlers::Herb::Herb.new(source, properties).src
+        cache.store(cache_key, compiled_src)
+        compiled += 1
+      rescue StandardError => e
+        errors += 1
+        puts "  Error: #{file}: #{e.message.lines.first&.chomp}"
+      end
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+    puts "Precompiled #{compiled} templates in #{format("%.2f", elapsed)}s"
+    puts "  Cache directory: #{cache.directory}"
+    puts "  Cache entries: #{cache.size}"
+    puts "  Errors: #{errors}" if errors > 0
+  end
+
+  namespace :cache do
+    desc "Clear the ReActionView template compilation cache"
+    task clear: :environment do
+      cache = ReActionView.cache
+      count = cache.size
+      cache.clear!
+
+      puts "Cleared #{count} cached entries"
+      puts "  Directory: #{cache.directory}"
+    end
+  end
+end

--- a/lib/tasks/reactionview.rake
+++ b/lib/tasks/reactionview.rake
@@ -31,15 +31,7 @@ namespace :reactionview do # rubocop:disable Metrics/BlockLength
         visitors: config.transform_visitors,
       }
 
-      cache_properties = {
-        filename: file,
-        validation_mode: config.validation_mode,
-        bufvar: "@output_buffer",
-        freeze_template_literals: !ActionView::Template.frozen_string_literal,
-        escapefunc: "",
-      }
-
-      cache_key = cache.key_for(source, cache_properties)
+      cache_key = cache.key_for(source, ReActionView::Template::Handlers::Herb.cache_properties)
 
       begin
         compiled_src = ReActionView::Template::Handlers::Herb::Herb.new(source, properties).src

--- a/test/reactionview/cache_test.rb
+++ b/test/reactionview/cache_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require "English"
 require "tmpdir"
 
 class ReActionView::CacheTest < Minitest::Spec
@@ -98,7 +99,7 @@ class ReActionView::CacheTest < Minitest::Spec
   end
 
   test "size returns 0 when directory does not exist" do
-    cache = ReActionView::Cache.new("/tmp/nonexistent_reactionview_cache_#{$$}")
+    cache = ReActionView::Cache.new("/tmp/nonexistent_reactionview_cache_#{$PID}")
     assert_equal 0, cache.size
   end
 

--- a/test/reactionview/cache_test.rb
+++ b/test/reactionview/cache_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "tmpdir"
+
+class ReActionView::CacheTest < Minitest::Spec
+  def setup
+    @cache_dir = Dir.mktmpdir("reactionview_cache_test_")
+    @cache = ReActionView::Cache.new(@cache_dir)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@cache_dir)
+  end
+
+  test "fetch returns nil on cache miss" do
+    assert_nil @cache.fetch("nonexistent_key")
+  end
+
+  test "store and fetch round-trip" do
+    @cache.store("abc123", "compiled_source_code")
+    assert_equal "compiled_source_code", @cache.fetch("abc123")
+  end
+
+  test "fetch reads from disk on cold memory" do
+    @cache.store("disk_key", "from_disk")
+
+    # Create a new cache instance pointing at the same directory (empty in-memory cache)
+    cold_cache = ReActionView::Cache.new(@cache_dir)
+    assert_equal "from_disk", cold_cache.fetch("disk_key")
+  end
+
+  test "fetch caches in memory after disk read" do
+    @cache.store("mem_key", "cached_value")
+
+    cold_cache = ReActionView::Cache.new(@cache_dir)
+    cold_cache.fetch("mem_key")
+
+    # Remove the file — should still return from memory
+    FileUtils.rm_rf(@cache_dir)
+    assert_equal "cached_value", cold_cache.fetch("mem_key")
+  end
+
+  test "store writes file to cache directory" do
+    @cache.store("file_key", "file_content")
+
+    path = File.join(@cache_dir, "file_key.rb")
+    assert File.exist?(path)
+    assert_equal "file_content", File.read(path)
+  end
+
+  test "key_for produces consistent SHA256 keys" do
+    key1 = @cache.key_for("hello", { filename: "test.erb" })
+    key2 = @cache.key_for("hello", { filename: "test.erb" })
+    assert_equal key1, key2
+    assert_match(/\A[0-9a-f]{64}\z/, key1)
+  end
+
+  test "key_for produces different keys for different sources" do
+    key1 = @cache.key_for("hello", { filename: "test.erb" })
+    key2 = @cache.key_for("world", { filename: "test.erb" })
+    refute_equal key1, key2
+  end
+
+  test "key_for produces different keys for different properties" do
+    key1 = @cache.key_for("hello", { filename: "a.erb" })
+    key2 = @cache.key_for("hello", { filename: "b.erb" })
+    refute_equal key1, key2
+  end
+
+  test "key_for produces different keys for different validation_mode" do
+    key1 = @cache.key_for("hello", { validation_mode: :raise })
+    key2 = @cache.key_for("hello", { validation_mode: :none })
+    refute_equal key1, key2
+  end
+
+  test "clear! removes all cached entries" do
+    @cache.store("key1", "value1")
+    @cache.store("key2", "value2")
+    assert_equal 2, @cache.size
+
+    @cache.clear!
+
+    assert_equal 0, @cache.size
+    assert_nil @cache.fetch("key1")
+    assert_nil @cache.fetch("key2")
+  end
+
+  test "size returns 0 for empty cache" do
+    assert_equal 0, @cache.size
+  end
+
+  test "size returns count of cached entries" do
+    @cache.store("a", "1")
+    @cache.store("b", "2")
+    @cache.store("c", "3")
+    assert_equal 3, @cache.size
+  end
+
+  test "size returns 0 when directory does not exist" do
+    cache = ReActionView::Cache.new("/tmp/nonexistent_reactionview_cache_#{$$}")
+    assert_equal 0, cache.size
+  end
+
+  test "store overwrites existing entry" do
+    @cache.store("overwrite_key", "old_value")
+    @cache.store("overwrite_key", "new_value")
+
+    assert_equal "new_value", @cache.fetch("overwrite_key")
+    assert_equal 1, @cache.size
+  end
+end

--- a/test/reactionview/cache_test.rb
+++ b/test/reactionview/cache_test.rb
@@ -63,8 +63,8 @@ class ReActionView::CacheTest < Minitest::Spec
   end
 
   test "key_for produces different keys for different properties" do
-    key1 = @cache.key_for("hello", { filename: "a.erb" })
-    key2 = @cache.key_for("hello", { filename: "b.erb" })
+    key1 = @cache.key_for("hello", { bufvar: "@output_buffer" })
+    key2 = @cache.key_for("hello", { bufvar: "@other_buffer" })
     refute_equal key1, key2
   end
 

--- a/test/reactionview/config_test.rb
+++ b/test/reactionview/config_test.rb
@@ -58,4 +58,26 @@ class ReActionView::ConfigTest < Minitest::Spec
 
     assert_equal :raise, config.validation_mode
   end
+
+  test "cache defaults to false" do
+    config = ReActionView::Config.new
+    assert_equal false, config.cache
+  end
+
+  test "cache_directory defaults to tmp/reactionview/cache" do
+    config = ReActionView::Config.new
+    assert_equal "tmp/reactionview/cache", config.cache_directory
+  end
+
+  test "cache can be set to true" do
+    config = ReActionView::Config.new
+    config.cache = true
+    assert_equal true, config.cache
+  end
+
+  test "cache_directory can be customized" do
+    config = ReActionView::Config.new
+    config.cache_directory = "/custom/path"
+    assert_equal "/custom/path", config.cache_directory
+  end
 end


### PR DESCRIPTION
## Context

As documented in https://github.com/marcoroth/reactionview/issues/96, we have observed a significant increase in ERB compilation overhead, which we see at boot time when using https://github.com/jhawthorn/actionview_precompiler and when ViewComponents compile their templates. On a test production deployment, we saw boot-time template precompilation jump from ~15s to nearly a minute, an unacceptable overhead to pay every time we boot a container.

## Proposed solution

This PR adds a `reactionview:precompile` rake task that compiles all files covered by the Herb configuration inclusion/exclusion rules. If `config.cache = true`, the compiled cache is used, skipping the work of compiling ERB to Ruby. In a test production deployment we saw equivalent boot-time precompilation times in the 15s range. 

If this change is generally deemed acceptable, I'd be happy to add docs to this PR.

## Alternatives considered

### Add cache to ActionView::Precompiler

I wrote https://github.com/jhawthorn/actionview_precompiler/pull/46 (cc @jhawthorn) and deployed it to a lab environment with good results. However, the optimization is really only necessary for Herb, so adding the complexity there felt like a bit much.

### Add cache to Herb

I wrote https://github.com/marcoroth/herb/compare/main...joelhawksley:herb:cache?expand=1 to add a cache to Herb instead. Unfortunately, ReActionView configures Herb with specific options which resulted in the cache not being hit.

## Further opportunities

In a preliminary benchmark, I tried compiling to Ruby instruction sequences, resulting in performance _faster_ than Erubi. I did not include this change here in order to keep things simple.

## References

Closes https://github.com/marcoroth/reactionview/issues/96