### PR TITLE
Respect `validation_mode` for external `.herb` templates

### DIFF
--- a/lib/reactionview/template/handlers/erb.rb
+++ b/lib/reactionview/template/handlers/erb.rb
@@ -11,7 +11,9 @@ module ReActionView
         def call(template, source)
           return super unless intercept_template?(template)
 
-          ::ReActionView::Template::Handlers::Herb.call(template, source)
+          ::ReActionView::Template::Handlers::Herb.call(
+            template, source, validation_mode: herb_validation_mode(template)
+          )
         rescue StandardError => e
           raise unless fall_back_to_erb?(template)
 
@@ -26,6 +28,13 @@ module ReActionView
           return false unless template.format == :html && ReActionView.config.intercept_erb
 
           local_template?(template) || ReActionView.config.external_template_mode != :skip
+        end
+
+        def herb_validation_mode(template)
+          return nil if local_template?(template)
+          return nil unless ReActionView.config.external_template_mode == :fallback
+
+          :raise
         end
 
         def fall_back_to_erb?(template)

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -10,7 +10,11 @@ module ReActionView
 
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
 
-        def call(template, source)
+        def self.call(template, source, validation_mode: nil)
+          new.call(template, source, validation_mode: validation_mode)
+        end
+
+        def call(template, source, validation_mode: nil)
           visitors = []
 
           if ::ReActionView.config.debug_mode_enabled? && local_template?(template)
@@ -23,7 +27,7 @@ module ReActionView
           config = {
             filename: template.identifier,
             project_path: Rails.root.to_s,
-            validation_mode: validation_mode_for(template),
+            validation_mode: validation_mode || ReActionView.config.validation_mode,
             content_for_head: reactionview_dev_tools_markup(template),
             visitors: visitors + ReActionView.config.transform_visitors,
           }
@@ -37,13 +41,6 @@ module ReActionView
           return false unless template.respond_to?(:identifier) && template.identifier
 
           template.identifier.include?("/layouts/")
-        end
-
-        def validation_mode_for(template)
-          return ReActionView.config.validation_mode if local_template?(template)
-          return ReActionView.config.validation_mode if ReActionView.config.external_template_mode == :compile
-
-          :raise
         end
 
         def active_support_editor

--- a/test/template/handlers/external_template_mode_test.rb
+++ b/test/template/handlers/external_template_mode_test.rb
@@ -127,6 +127,28 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
     ReActionView.config.validation_mode = nil
   end
 
+  test "external .herb templates use the configured validation mode" do
+    ReActionView.config.external_template_mode = :fallback
+    ReActionView.config.validation_mode = :overlay
+
+    template = ActionView::Template.new(
+      INVALID,
+      "/gems/some_gem/app/views/x.html.herb",
+      ReActionView::Template::Handlers::Herb,
+      virtual_path: "x",
+      format: :html,
+      locals: []
+    )
+
+    compiled = Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      ReActionView::Template::Handlers::Herb.call(template, INVALID)
+    end
+
+    assert_includes compiled, "data-herb-validation-error"
+  ensure
+    ReActionView.config.validation_mode = nil
+  end
+
   test "local template failures always raise, whatever the mode" do
     ReActionView.config.external_template_mode = :fallback
     ReActionView.config.validation_mode = :raise


### PR DESCRIPTION
Follow up on #115.

When a gem ships a `.html.herb` template, it reaches `ReActionView::Template::Handlers::Herb` straight from the railtie. It never passes through `Handlers::ERB`, so nothing is in a position to rescue it.

#115 nonetheless forced `validation_mode: :raise` for every external template, including those, which turned what used to be a validation overlay into an uncaught exception on a template the application cannot edit:

```ruby
ReActionView.config.validation_mode = :overlay
ReActionView.config.external_template_mode = :fallback

# /gems/some_gem/app/views/x.html.herb
# before: Herb::Engine::CompilationError
# after:  compiles, with the usual validation overlay
```

The mistake was putting the decision in `Handlers::Herb`, which cannot tell whether its caller will rescue. `validation_mode_for` is gone, and the mode is now passed in by the handler that owns the `rescue`.

Related #115
