### PR TITLE
Add regression test for heredoc with trailing arguments

### DIFF
--- a/test/snapshots/herb/template_handler_test/test_0031_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_compiled_ffc55de9e7891578a81f0a2b0c1346a5.txt
+++ b/test/snapshots/herb/template_handler_test/test_0031_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_compiled_ffc55de9e7891578a81f0a2b0c1346a5.txt
@@ -1,0 +1,8 @@
+ @output_buffer.append=(method_call <<~GRAPHQL, variables
+  query {
+    field
+  }
+GRAPHQL
+);
+ @output_buffer.safe_append='
+'.freeze;@output_buffer

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -366,6 +366,19 @@ class Herb::TemplateHandlerTest < Minitest::Spec
     assert_compiled_snapshot(template)
   end
 
+  test "heredoc with trailing arguments compiles to valid Ruby" do
+    template = <<~ERB
+      <%= method_call <<~GRAPHQL, variables
+        query {
+          field
+        }
+      GRAPHQL
+      %>
+    ERB
+
+    assert_compiled_snapshot(template)
+  end
+
   test "renders templates that are not local with ActionView's ERB handler" do
     ReActionView.config.intercept_erb = true
 


### PR DESCRIPTION
The compiled Ruby for an ERB expression containing a heredoc needs the closing parenthesis on its own line after the heredoc terminator. That is handled by `Herb::Engine#trailing_newline`, but the handler override in `ReActionView::Template::Handlers::Herb::Herb#add_expression` had no test covering it.

Ported from #78 by @pinzonjulian, which is otherwise obsolete since the fix landed upstream in marcoroth/herb#1206.

Resolves #78