### PR TITLE
Only emit dev tools markup when debug mode is enabled

### DIFF
--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -76,29 +76,27 @@ module ReActionView
         end
 
         def reactionview_dev_tools_markup(template)
+          return nil unless ::ReActionView.config.debug_mode_enabled?
           return nil unless layout_template?(template)
           return nil unless local_template?(template)
 
-          markup = +""
+          <<~HTML
+            <meta name="herb-debug-mode" content="true">
+            <meta name="herb-project-path" content="#{Rails.root}">
+            #{dev_server_port_meta_tag}
+            #{editor_meta_tag}
 
-          if ::ReActionView.config.debug_mode_enabled?
-            markup << <<~HTML
-              <meta name="herb-debug-mode" content="true">
-              <meta name="herb-project-path" content="#{Rails.root}">
-              #{dev_server_port_meta_tag}
-              #{editor_meta_tag}
+            #{ActionController::Base.new.view_context.javascript_include_tag "reactionview-dev-tools.umd.js", defer: true}
+            #{dismiss_hint_template}
+          HTML
+        end
 
-              #{ActionController::Base.new.view_context.javascript_include_tag "reactionview-dev-tools.umd.js", defer: true}
-            HTML
-          end
+        def dismiss_hint_template
+          return unless ::ReActionView.config.validation_mode == :overlay
 
-          if ::ReActionView.config.validation_mode == :overlay
-            markup << <<~HTML
-              <template data-herb-dismiss-hint>You can also disable this overlay by setting <code style="color: #ffeb3b; font-family: monospace; font-size: 12pt;">config.validation_mode = :none</code> in <code style="color: #ffeb3b; font-family: monospace; font-size: 12pt;">config/initializers/reactionview.rb</code>.</template>
-            HTML
-          end
-
-          markup.presence
+          <<~HTML.chomp
+            <template data-herb-dismiss-hint>You can also disable this overlay by setting <code style="color: #ffeb3b; font-family: monospace; font-size: 12pt;">config.validation_mode = :none</code> in <code style="color: #ffeb3b; font-family: monospace; font-size: 12pt;">config/initializers/reactionview.rb</code>.</template>
+          HTML
         end
       end
     end

--- a/test/template/handlers/dev_tools_markup_test.rb
+++ b/test/template/handlers/dev_tools_markup_test.rb
@@ -16,9 +16,6 @@ class ReActionView::DevToolsMarkupTest < Minitest::Spec
 
   before do
     @previous_debug_mode = ReActionView.config.debug_mode
-    @previous_validation_mode = ReActionView.config.validation_mode
-
-    ReActionView.config.intercept_erb = true
   end
 
   after do

--- a/test/template/handlers/dev_tools_markup_test.rb
+++ b/test/template/handlers/dev_tools_markup_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+require "action_controller"
+
+class ReActionView::DevToolsMarkupTest < Minitest::Spec
+  RAILS_ROOT = "/app"
+  LAYOUT = "/app/app/views/layouts/application.html.erb"
+  MAILER_LAYOUT = "/app/app/views/layouts/mailer.html.erb"
+  VIEW = "/app/app/views/users/show.html.erb"
+
+  SOURCE = %(<html><head></head><body></body></html>)
+
+  DISMISS_HINT = "data-herb-dismiss-hint"
+
+  before do
+    @previous_debug_mode = ReActionView.config.debug_mode
+    @previous_validation_mode = ReActionView.config.validation_mode
+
+    ReActionView.config.intercept_erb = true
+  end
+
+  after do
+    ReActionView.config.debug_mode = @previous_debug_mode
+    ReActionView.config.validation_mode = nil
+  end
+
+  def compile(identifier: LAYOUT, virtual_path: "layouts/application")
+    template = ActionView::Template.new(
+      SOURCE,
+      identifier,
+      ReActionView::Template::Handlers::Herb,
+      virtual_path: virtual_path,
+      format: :html,
+      locals: []
+    )
+
+    Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      ReActionView::Template::Handlers::Herb.call(template, SOURCE)
+    end
+  end
+
+  test "does not emit the dismiss hint when debug mode is off" do
+    ReActionView.config.debug_mode = false
+    ReActionView.config.validation_mode = :overlay
+
+    refute_includes compile, DISMISS_HINT
+  end
+
+  test "does not emit the dismiss hint in mailer layouts when debug mode is off" do
+    ReActionView.config.debug_mode = false
+    ReActionView.config.validation_mode = :overlay
+
+    refute_includes compile(identifier: MAILER_LAYOUT, virtual_path: "layouts/mailer"), DISMISS_HINT
+  end
+
+  test "emits nothing at all into the head when debug mode is off" do
+    ReActionView.config.debug_mode = false
+    ReActionView.config.validation_mode = :overlay
+
+    compiled = compile
+
+    refute_includes compiled, "herb-debug-mode"
+    refute_includes compiled, "reactionview-dev-tools"
+    refute_includes compiled, DISMISS_HINT
+  end
+
+  test "emits the dismiss hint when debug mode is on and validation mode is :overlay" do
+    ReActionView.config.debug_mode = true
+    ReActionView.config.validation_mode = :overlay
+
+    compiled = compile
+
+    assert_includes compiled, DISMISS_HINT
+    assert_includes compiled, "herb-debug-mode"
+  end
+
+  test "does not emit the dismiss hint when validation mode is not :overlay" do
+    ReActionView.config.debug_mode = true
+    ReActionView.config.validation_mode = :none
+
+    compiled = compile
+
+    refute_includes compiled, DISMISS_HINT
+    assert_includes compiled, "herb-debug-mode"
+  end
+
+  test "emits nothing for templates that are not layouts" do
+    ReActionView.config.debug_mode = true
+    ReActionView.config.validation_mode = :overlay
+
+    compiled = compile(identifier: VIEW, virtual_path: "users/show")
+
+    refute_includes compiled, DISMISS_HINT
+    refute_includes compiled, "herb-debug-mode"
+  end
+end


### PR DESCRIPTION
This pull request fixes the ReActionView dismiss hint rendering as visible text at the top of production emails.

`reactionview_dev_tools_markup` gated its meta tags and the dev tools script tag on `debug_mode_enabled?`, but the dismiss hint sat outside that block, gated only on the validation mode:

```ruby
if ::ReActionView.config.debug_mode_enabled?
  markup << # meta tags + <script src="reactionview-dev-tools.umd.js">
end

if ::ReActionView.config.validation_mode == :overlay
  markup << %(<template data-herb-dismiss-hint>You can also disable this overlay ...</template>)
end
```

`:overlay` is the default outside of test, so with the recommended `config.debug_mode = Rails.env.development?` the hint was still injected into every layout in production, including `layouts/mailer.html.erb`.

Browsers never render the contents of a `<template>`, which is why this was invisible on the web and went unnoticed. Email clients do not implement `<template>`, so they discard the tag and keep the text inside it and display it.

Resolves #95
