### PR TITLE
Fix dev tools event listener leak on Turbo navigation

### DIFF
--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -106,8 +106,6 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   }
 
   document.addEventListener("turbo:load", initializeDevTools)
-  document.addEventListener("turbo:render", initializeDevTools)
-  document.addEventListener("turbo:visit", initializeDevTools)
 }
 
 declare global {

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -72,6 +72,10 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   let isInitializing = false
 
   const initializeDevTools = () => {
+    if (ReActionViewDevTools.getInstance()) {
+      return
+    }
+
     if (isInitializing) {
       console.log("ReActionView dev tools initialization already in progress, skipping...")
 
@@ -109,8 +113,6 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   }
 
   document.addEventListener("turbo:load", initializeDevTools)
-  document.addEventListener("turbo:render", initializeDevTools)
-  document.addEventListener("turbo:visit", initializeDevTools)
 }
 
 declare global {


### PR DESCRIPTION
`initializeDevTools` was registered on three Turbo events, so one navigation called it three times.

```ts
document.addEventListener("turbo:load", initializeDevTools)
document.addEventListener("turbo:render", initializeDevTools)
document.addEventListener("turbo:visit", initializeDevTools)
```

One of them is enough. `turbo:load` fires for every navigation this needs to react to, and the other two only add work.

#### The guard this no longer adds

An earlier version of this also returned early whenever a wrapper instance existed. That guard has landed since, in #126, and it is shaped deliberately:

```ts
if (ReActionViewDevTools.getInstance() && HerbDevTools.instance) {
  return
}
```

The second half carries the weight. `destroy` stops the dev tools it holds and clears its own reference to them, and it leaves the static wrapper instance alone, so `getInstance()` keeps answering forever once anything has constructed one. A guard on the wrapper by itself would mean initialization could never happen twice, and the compile error page from #132 needs it to, since it loads the dev tools again over a page that has already failed to compile.

Nothing leaks either way. The first `turbo:load` initializes and every event after it returns early.

#### The follow-up is already in

This used to list what had to happen before marcoroth/herb#2081 could reach anyone, because the gem serves a vendored bundle and an application never resolves `@herb-tools/dev-tools` itself. Both steps have happened. The package is pinned to a build of herb's main branch, and `ReActionViewDevTools#destroy` delegates to `stop()` instead of reaching into the DOM for `.herb-floating-menu`.

That teardown is in the bundle this ships, which now carries 20 `removeEventListener` calls, three of them for Turbo events.

Resolves #108