### PR TITLE
Compile a template to its values when a request asks for them

### DIFF
--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -2,11 +2,14 @@
 
 module ReActionView
   class Config
+    EXTERNAL_TEMPLATE_MODES = %i[fallback skip compile].freeze
+    SLOT_MODES = %i[server client].freeze
+
     attr_accessor :intercept_erb
     attr_accessor :debug_mode
     attr_accessor :transform_visitors
 
-    EXTERNAL_TEMPLATE_MODES = %i[fallback skip compile].freeze
+    attr_reader :slots
 
     attr_writer :dev_server_port
     attr_writer :project_path
@@ -19,6 +22,25 @@ module ReActionView
       @external_template_mode = nil
       @transform_visitors = []
       @project_path = nil
+      @slots = false
+    end
+
+    def slots=(value)
+      unless [nil, true, false].include?(value) || SLOT_MODES.include?(value)
+        raise ArgumentError, "slots must be true, false, or one of #{SLOT_MODES.inspect}, got #{value.inspect}"
+      end
+
+      @slots = value
+    end
+
+    def slot_mode_for(source)
+      ::Herb::Engine::Slots::Visitor.directive_mode(source) || default_slot_mode
+    end
+
+    def default_slot_mode
+      return nil unless slots
+
+      slots == true ? :server : slots
     end
 
     def external_template_mode

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -2,8 +2,10 @@
 
 require "herb"
 require "herb/engine"
+require "herb/engine/slots/dynamics_compiler"
 
 require "herb/engine/visitors/debug_visitor"
+require "herb/engine/slots/visitor"
 require "herb/engine/visitors/content_for_visitor"
 require "herb/engine/validators"
 
@@ -16,6 +18,14 @@ module ReActionView
         autoload :Herb, "reactionview/template/handlers/herb/herb"
 
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
+
+        VALUES_ESCAPING = {
+          escape: true,
+          escapefunc: "::ERB::Util.h",
+          attrfunc: nil,
+          jsfunc: nil,
+          cssfunc: nil,
+        }.freeze
 
         def self.call(template, source, validation_mode: nil)
           new.call(template, source, validation_mode: validation_mode)
@@ -37,10 +47,26 @@ module ReActionView
             visitors: visitors,
           }
 
+          return values_source(template, source, config) if values_format?(template)
+
+          config[:visitors] = [*visitors, *slot_visitors(template, source)]
+
           erb_implementation.new(source, config).src
         end
 
         private
+
+        def values_source(template, source, config)
+          visitor = slot_visitors(template, source, mark: false).first
+
+          return "{}" unless visitor
+
+          ::Herb::Engine::Slots::DynamicsCompiler.new(source, config.merge(slot_visitor: visitor, **VALUES_ESCAPING)).src
+        end
+
+        def values_format?(template)
+          template.respond_to?(:format) && template.format == :slots
+        end
 
         def validation_visitors(mode)
           case mode
@@ -62,6 +88,16 @@ module ReActionView
           return [] if markup.nil? || markup.empty?
 
           [::Herb::Engine::ContentForVisitor.new(markup, tag_name: "head")]
+        end
+
+        def slot_visitors(template, source, mark: true)
+          return [] unless values_format?(template) || (template.respond_to?(:format) && template.format == :html)
+
+          mode = ::ReActionView.config.slot_mode_for(source)
+
+          return [] unless mode
+
+          [::Herb::Engine::Slots::Visitor.new(mode: mode, mark: mark)]
         end
 
         def layout_template?(template)

--- a/test/template/handlers/values_test.rb
+++ b/test/template/handlers/values_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+require "action_controller"
+
+class ReActionView::ValuesTest < Minitest::Spec
+  RAILS_ROOT = "/app"
+  VIEW = "/app/app/views/users/show.html.erb"
+
+  class View
+    def initialize(**assigns)
+      assigns.each { |name, value| instance_variable_set(:"@#{name}", value) }
+    end
+  end
+
+  before do
+    @previous_slots = ReActionView.config.slots
+
+    ReActionView.config.debug_mode = false
+    ReActionView.config.slots = true
+  end
+
+  after do
+    ReActionView.config.slots = @previous_slots
+  end
+
+  def compile(source, format:)
+    template = ActionView::Template.new(
+      source,
+      VIEW,
+      ReActionView::Template::Handlers::Herb,
+      virtual_path: "users/show",
+      format: format,
+      locals: []
+    )
+
+    Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      ReActionView::Template::Handlers::Herb.call(template, source)
+    end
+  end
+
+  def values(source, view = View.new)
+    view.instance_eval(compile(source, format: :slots))
+  end
+
+  def html(source, view = View.new)
+    view.instance_variable_set(:@output_buffer, ActionView::OutputBuffer.new)
+
+    view.instance_eval(compile(source, format: :html)).to_s
+  end
+
+  test "the two compiles name the same version, which is what says they belong together" do
+    source = %(<div class="<%= @tone %>"><h1><%= @title %></h1></div>)
+
+    assert_includes html(source), ":#{values(source)[:version]}:"
+  end
+
+  test "a value arrives escaped the way the page would have written it" do
+    source = "<p><%= @name %></p>"
+    view = View.new(name: "Ada <b>L</b>")
+
+    assert_equal "Ada &lt;b&gt;L&lt;/b&gt;", values(source, view)[:slots][0]
+    assert_includes html(source, View.new(name: "Ada <b>L</b>")), "Ada &lt;b&gt;L&lt;/b&gt;"
+  end
+
+  test "an attribute is escaped as the page escapes it, not as an attribute" do
+    source = %(<div title="<%= @text %>"></div>)
+    view = View.new(text: %(a > b))
+
+    assert_equal "a &gt; b", values(source, view)[:slots][0]
+    assert_includes html(source, View.new(text: %(a > b))), "a &gt; b"
+  end
+
+  test "a value already marked html_safe is left alone, as the page leaves it" do
+    source = "<p><%= @markup %></p>"
+
+    assert_equal "<b>bold</b>", values(source, View.new(markup: "<b>bold</b>".html_safe))[:slots][0]
+  end
+
+  test "every value it reports appears in the page rendered from the same state" do
+    source = %(<div class="<%= @tone %>"><h1><%= @title %></h1><% @items.each do |i| %><li id="<%= i %>"><%= i %></li><% end %></div>)
+    state = { tone: "calm", title: "Hello", items: %w[a b] }
+
+    rendered = html(source, View.new(**state))
+    reported = values(source, View.new(**state))[:slots]
+
+    assert_equal "calm", reported[0]
+    assert_equal({ "a" => { 3 => "a", 4 => "a" }, "b" => { 3 => "b", 4 => "b" } }, reported[2][:items])
+
+    flatten(reported).each { |value| assert_includes rendered, value }
+  end
+
+  test "it counts a rendering the way the region marker counts it" do
+    source = "<p><%= @name %></p>"
+    view = View.new(name: "x")
+
+    assert_equal [0, 1, 2], Array.new(3) { view.instance_eval(compile(source, format: :slots))[:occurrence] }
+  end
+
+  test "a template nothing asked to mark reports no values, since nothing can address it" do
+    ReActionView.config.slots = false
+
+    assert_empty values("<p><%= @name %></p>")
+  end
+
+  test "the html compile still gets its markers" do
+    assert_includes html("<p><%= @name %></p>"), "herb-region:app/views/users/show.html.erb"
+  end
+
+  def flatten(slots, found = [])
+    slots.each_value do |value|
+      case value
+      when String then found << value
+      when Hash
+        flatten(value[:slots], found) if value[:slots]
+        value[:items]&.each_value { |item| flatten(item, found) }
+      end
+    end
+
+    found
+  end
+end


### PR DESCRIPTION
This pull request gives the Herb handler a second compile. A template asked for as `:html` still compiles to the page it always did, and the same template asked for as `:slots` compiles to the values of its dynamic parts.

A page and its values have to agree about what a slot is, so both compiles run the same visitor stack and differ only at the end. The `:html` compile marks its slots in the markup. The `:slots` compile runs `Herb::Engine::Slots::DynamicsCompiler` over the visitor the `:html` compile would have used, with marking off, and evaluates to a hash instead of a buffer.

```erb
<div class="<%= @tone %>"><h1><%= @title %></h1></div>
```

```ruby
# format: :html
"<div class=\"calm\"><h1>Hello</h1></div>"

# format: :slots
{ version: "…", slots: ["calm", "Hello"] }
```

A value is escaped the way the page would have written it, which is what lets a client put it back where it came from. `<%= @name %>` inside a `<p>` arrives HTML escaped, and the same expression inside `title="…"` arrives escaped as the page escapes it, not as an attribute. Both compiles stamp the same version, a digest of a template's slots, so a payload built from one template cannot be applied to a page rendered from another.

Slots are off by default. `config.slots` takes `true` for server rendered branches, `:client` to also send the branches a request did not take, and a template overrides the project setting with `<%# herb:slots … %>`.