### PR TITLE
Serve a template's values as a format a request can ask for

### DIFF
--- a/lib/reactionview.rb
+++ b/lib/reactionview.rb
@@ -17,6 +17,10 @@ require_relative "reactionview/config"
 
 # require_relative "reactionview/source_annotation_extractor"
 
+require_relative "reactionview/slots"
+require_relative "reactionview/slots/resolver"
+require_relative "reactionview/slots/rendering"
+
 require_relative "reactionview/template/local_template"
 
 require_relative "reactionview/template/handlers/erb"

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -55,6 +55,20 @@ module ReActionView
       ActionController::Base.helpers.asset_path("reactionview-dev-tools.esm.js")
     end
 
+    initializer "reactionview.slots" do |app|
+      next unless ReActionView.config.slots
+
+      Mime::Type.register ReActionView::Slots::MIME_TYPE, ReActionView::Slots::FORMAT unless Mime[ReActionView::Slots::FORMAT]
+
+      ActiveSupport.on_load(:action_controller_base) do
+        prepend ReActionView::Slots::Rendering
+
+        app.config.paths["app/views"].existent.each do |path|
+          prepend_view_path ReActionView::Slots::Resolver.new(path)
+        end
+      end
+    end
+
     initializer "reactionview.register_herb_handler" do
       ActiveSupport.on_load(:action_view) do
         ActionView::Template.register_template_handler :herb, ReActionView::Template::Handlers::Herb

--- a/lib/reactionview/slots.rb
+++ b/lib/reactionview/slots.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ReActionView
+  module Slots
+    FORMAT = :slots #: Symbol
+    MIME_TYPE = "application/vnd.herb.slots+json" #: String
+  end
+end

--- a/lib/reactionview/slots/rendering.rb
+++ b/lib/reactionview/slots/rendering.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "json"
+
+module ReActionView
+  module Slots
+    module Rendering
+      def _normalize_options(options)
+        super
+
+        options[:layout] = false if slots_request?
+
+        options
+      end
+
+      def render_to_body(options = {})
+        rendered = super
+
+        rendered.is_a?(::Hash) ? ::JSON.generate(rendered) : rendered
+      end
+
+      private
+
+      def slots_request?
+        respond_to?(:request) && request&.format&.symbol == Slots::FORMAT
+      end
+    end
+  end
+end

--- a/lib/reactionview/slots/resolver.rb
+++ b/lib/reactionview/slots/resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ReActionView
+  module Slots
+    class Resolver < ActionView::FileSystemResolver
+      private
+
+      def build_unbound_template(template)
+        unbound = super
+        details = unbound.details
+
+        return unbound unless details.format == :html
+
+        ActionView::UnboundTemplate.new(
+          source_for_template(template),
+          template,
+          details: ActionView::TemplateDetails.new(details.locale, details.handler, Slots::FORMAT, details.variant),
+          virtual_path: unbound.virtual_path
+        )
+      end
+
+      def unbound_templates_from_path(path)
+        super.select { |unbound| unbound.format == Slots::FORMAT }
+      end
+    end
+  end
+end

--- a/lib/reactionview/template/handlers/erb.rb
+++ b/lib/reactionview/template/handlers/erb.rb
@@ -6,6 +6,8 @@ module ReActionView
       class ERB < ActionView::Template::Handlers::ERB
         include ReActionView::Template::LocalTemplate
 
+        INTERCEPTED_FORMATS = [:html, ::ReActionView::Slots::FORMAT].freeze
+
         autoload :Herb, "reactionview/template/handlers/herb/herb"
 
         def call(template, source)
@@ -25,7 +27,7 @@ module ReActionView
         private
 
         def intercept_template?(template)
-          return false unless template.format == :html && ReActionView.config.intercept_erb
+          return false unless INTERCEPTED_FORMATS.include?(template.format) && ReActionView.config.intercept_erb
           return false if framework_template?(template)
 
           local_template?(template) || ReActionView.config.external_template_mode != :skip

--- a/test/slots/rendering_test.rb
+++ b/test/slots/rendering_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "action_controller"
+require "tmpdir"
+
+class ReActionView::Slots::RenderingTest < Minitest::Spec
+  SOURCE = %(<div class="<%= @tone %>"><h1><%= @title %></h1></div>)
+
+  before do
+    @previous = [ReActionView.config.slots, ReActionView.config.intercept_erb, ReActionView.config.debug_mode]
+
+    ReActionView.config.slots = true
+    ReActionView.config.intercept_erb = true
+    ReActionView.config.debug_mode = false
+
+    ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::ERB
+    Mime::Type.register(ReActionView::Slots::MIME_TYPE, ReActionView::Slots::FORMAT) unless Mime[ReActionView::Slots::FORMAT]
+  end
+
+  after do
+    ReActionView.config.slots, ReActionView.config.intercept_erb, ReActionView.config.debug_mode = @previous
+
+    ActionView::Template.register_template_handler :erb, ActionView::Template::Handlers::ERB
+  end
+
+  around do |work|
+    Dir.mktmpdir do |root|
+      @root = root
+
+      FileUtils.mkdir_p(File.join(root, "users"))
+      File.write(File.join(root, "users", "show.html.erb"), SOURCE)
+
+      work.call
+    end
+  end
+
+  class Controller
+    def render_to_body(options = {})
+      options[:body]
+    end
+  end
+
+  class Serializing < Controller
+    prepend ReActionView::Slots::Rendering
+  end
+
+  Format = Struct.new(:symbol)
+  Request = Struct.new(:format)
+
+  class Normalizing
+    attr_reader :request
+
+    def initialize(format)
+      @request = Request.new(Format.new(format))
+    end
+
+    def _normalize_options(options)
+      options
+    end
+  end
+
+  class NormalizingWithSlots < Normalizing
+    prepend ReActionView::Slots::Rendering
+  end
+
+  def render(format, **assigns)
+    lookup = ActionView::LookupContext.new(
+      [ReActionView::Slots::Resolver.new(@root), ActionView::FileSystemResolver.new(@root)]
+    )
+
+    lookup.formats = [format]
+
+    view = ActionView::Base.with_empty_template_cache.new(lookup, {}, nil)
+    assigns.each { |name, value| view.instance_variable_set(:"@#{name}", value) }
+
+    view.render(template: "users/show")
+  end
+
+  test "the format is one ActionView will accept" do
+    assert_includes ActionView::Template::Types.symbols, ReActionView::Slots::FORMAT
+  end
+
+  test "a values request renders the payload rather than the page" do
+    payload = render(:slots, tone: "calm", title: "Hello")
+
+    assert_equal({ 0 => "calm", 1 => "Hello" }, payload[:slots])
+    assert_equal "users/show", payload[:template].split("/").last(2).join("/").sub(".html.erb", "")
+  end
+
+  test "the payload names the version the page was marked with" do
+    payload = render(:slots, tone: "calm", title: "Hello")
+
+    assert_includes render(:html, tone: "calm", title: "Hello"), ":#{payload[:version]}:"
+  end
+
+  test "an html request still renders the page, markers and all" do
+    rendered = render(:html, tone: "calm", title: "Hello")
+
+    assert_includes rendered, "herb-region:"
+    assert_includes rendered, %(<div class="calm" data-herb-slot="0:attribute:class">)
+  end
+
+  test "a value is escaped the way the page escaped it" do
+    payload = render(:slots, tone: "calm", title: "Hi <b>")
+
+    assert_equal "Hi &lt;b&gt;", payload[:slots][1]
+    assert_includes render(:html, tone: "calm", title: "Hi <b>"), "Hi &lt;b&gt;"
+  end
+
+  describe "handing the payload to the response" do
+    test "serializes the values, which nothing below here would do" do
+      body = Serializing.new.render_to_body(body: { template: "a", slots: { 0 => "x" } })
+
+      assert_equal %({"template":"a","slots":{"0":"x"}}), body
+    end
+
+    test "leaves a rendered page alone" do
+      assert_equal "<p>hi</p>", Serializing.new.render_to_body(body: "<p>hi</p>")
+    end
+  end
+
+  describe "the layout a values request does not get" do
+    test "renders the action and nothing around it" do
+      options = NormalizingWithSlots.new(ReActionView::Slots::FORMAT)._normalize_options({})
+
+      assert_equal false, options[:layout]
+    end
+
+    test "leaves a page request to render its layout as usual" do
+      options = NormalizingWithSlots.new(:html)._normalize_options({})
+
+      refute_includes options.keys, :layout
+    end
+  end
+end

--- a/test/slots/resolver_test.rb
+++ b/test/slots/resolver_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "tmpdir"
+
+class ReActionView::Slots::ResolverTest < Minitest::Spec
+  def details(formats)
+    { locale: [:en], formats: formats, variants: [], handlers: [:herb, :erb] }
+  end
+
+  def find(resolver, name, prefix, formats:, partial: false)
+    resolver.find_all(name, prefix, partial, details(formats), nil, [])
+  end
+
+  around do |work|
+    Dir.mktmpdir do |root|
+      @root = root
+
+      FileUtils.mkdir_p(File.join(root, "users"))
+      FileUtils.mkdir_p(File.join(root, "layouts"))
+
+      File.write(File.join(root, "users", "show.html.erb"), "<p><%= @name %></p>")
+      File.write(File.join(root, "users", "_card.html.erb"), "<b><%= @name %></b>")
+      File.write(File.join(root, "users", "export.text.erb"), "<%= @name %>")
+      File.write(File.join(root, "layouts", "application.html.erb"), "<%= yield %>")
+
+      @resolver = ReActionView::Slots::Resolver.new(root)
+
+      work.call
+    end
+  end
+
+  test "resolves the html template a values request asked for" do
+    found = find(@resolver, "show", "users", formats: [:slots])
+
+    assert_equal 1, found.size
+    assert_equal :slots, found.first.format
+    assert_equal "users/show", found.first.virtual_path
+  end
+
+  test "hands back the markup template's own source, so there is one template and not two" do
+    found = find(@resolver, "show", "users", formats: [:slots])
+
+    assert_equal "<p><%= @name %></p>", found.first.source
+    assert_match(/show\.html\.erb\z/, found.first.identifier)
+  end
+
+  test "resolves a partial too, since a page is mostly partials" do
+    found = find(@resolver, "card", "users", formats: [:slots], partial: true)
+
+    assert_equal :slots, found.first.format
+  end
+
+  test "leaves an html request to the resolver Rails already built" do
+    assert_empty find(@resolver, "show", "users", formats: [:html])
+  end
+
+  test "special cases no path, since nothing asks it for a layout" do
+    assert_equal :slots, find(@resolver, "application", "layouts", formats: [:slots]).first.format
+  end
+
+  test "resolves nothing for a format that was never markup" do
+    assert_empty find(@resolver, "export", "users", formats: [:slots])
+  end
+end

--- a/test/template/handlers/slots_test.rb
+++ b/test/template/handlers/slots_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+require "action_controller"
+
+class ReActionView::SlotsTest < Minitest::Spec
+  RAILS_ROOT = "/app"
+  VIEW = "/app/app/views/users/show.html.erb"
+
+  before do
+    @previous_slots = ReActionView.config.slots
+
+    ReActionView.config.debug_mode = false
+    ReActionView.config.slots = false
+  end
+
+  after do
+    ReActionView.config.slots = @previous_slots
+  end
+
+  def compile(source, identifier: VIEW, format: :html)
+    template = ActionView::Template.new(
+      source,
+      identifier,
+      ReActionView::Template::Handlers::Herb,
+      virtual_path: "users/show",
+      format: format,
+      locals: []
+    )
+
+    Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      ReActionView::Template::Handlers::Herb.call(template, source)
+    end
+  end
+
+  test "a template gets no markers when nothing asks for them" do
+    compiled = compile("<p><%= @name %></p>")
+
+    refute_includes compiled, "herb-slot"
+    refute_includes compiled, "herb-region"
+  end
+
+  test "a template that asks for slots itself gets them" do
+    compiled = compile("<%# herb:slots %>\n<p><%= @name %></p>")
+
+    assert_includes compiled, "herb-region:app/views/users/show.html.erb"
+    assert_includes compiled, %(data-herb-slot="0:child")
+  end
+
+  test "turning slots on marks every template" do
+    ReActionView.config.slots = true
+
+    assert_includes compile("<p><%= @name %></p>"), "herb-region:"
+  end
+
+  test "the project default decides who renders a branch" do
+    ReActionView.config.slots = :client
+
+    compiled = compile("<div><% if @admin %><b>secret</b><% else %><i>guest</i><% end %></div>")
+
+    assert_includes compiled, "herb-branch:0:0"
+    assert_includes compiled, "_herb_covered"
+  end
+
+  test "a template overrides the project default" do
+    ReActionView.config.slots = :client
+
+    compiled = compile("<%# herb:slots server %>\n<div><% if @admin %><b>secret</b><% end %></div>")
+
+    assert_includes compiled, "herb-slot:0:conditional"
+    refute_includes compiled, "_herb_covered"
+  end
+
+  test "a template can ask for client mode while the project stays on server" do
+    ReActionView.config.slots = true
+
+    compiled = compile("<%# herb:slots client %>\n<div><% if @admin %><b>secret</b><% end %></div>")
+
+    assert_includes compiled, "_herb_covered"
+  end
+
+  test "only html gets markers" do
+    ReActionView.config.slots = true
+
+    refute_includes compile("Hello <%= @name %>", format: :text), "herb-region"
+  end
+
+  test "an unknown mode is refused" do
+    error = assert_raises(ArgumentError) { ReActionView.config.slots = :nonsense }
+
+    assert_match(/slots must be/, error.message)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "rails"
 require "action_view"
+require "action_view/base"
 require "reactionview"
 
 require "pathname"


### PR DESCRIPTION
Based on #123, which taught the handler to compile a template to its values. This pull request makes those values something a request can ask for.

`application/vnd.herb.slots+json` registers as the `:slots` format, so a controller answers for it the way it answers for any other.

```ruby
respond_to do |format|
  format.html
  format.slots
end
```

Nothing has to be written for it. `ReActionView::Slots::Resolver` prepends itself to the view paths and presents every `.html.erb` template under the `:slots` format as well, so `users/show.html.erb` answers both. A slots request renders without a layout, since a layout has no dynamic parts of the page in it, and `render_to_body` generates JSON when what came back is the hash the values compile produces.

The ERB handler intercepts the new format alongside `:html`, which is what routes a slots request into the values compile instead of Rails' own ERB.