### PR TITLE
Give a page the map of what its state reaches

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -69,6 +69,21 @@ module ReActionView
       end
     end
 
+    initializer "reactionview.slots.reloading" do |app|
+      next unless ReActionView.config.slots
+
+      views = app.config.paths["app/views"].existent
+
+      next if views.empty?
+
+      watcher = app.config.file_watcher.new([], views.index_with { %w[erb] }) do
+        ReActionView::Slots.reset_dependencies!
+      end
+
+      app.reloaders << watcher
+      app.reloader.to_run { watcher.execute_if_updated }
+    end
+
     initializer "reactionview.register_herb_handler" do
       ActiveSupport.on_load(:action_view) do
         ActionView::Template.register_template_handler :herb, ReActionView::Template::Handlers::Herb

--- a/lib/reactionview/slots.rb
+++ b/lib/reactionview/slots.rb
@@ -4,5 +4,23 @@ module ReActionView
   module Slots
     FORMAT = :slots #: Symbol
     MIME_TYPE = "application/vnd.herb.slots+json" #: String
+    REGION_MARKER = "herb-region:" #: String
+
+    #: () -> untyped
+    def self.dependencies
+      root = ReActionView.config.project_path
+
+      @dependencies = nil if @root != root
+      @root = root
+      @dependencies ||= ::Herb::Engine::Slots::Dependencies.new(
+        root,
+        compile: ->(source, path) { ReActionView::Template::Handlers::Herb.compile_for_dependencies(source, path) }
+      )
+    end
+
+    #: () -> void
+    def self.reset_dependencies!
+      @dependencies = nil
+    end
   end
 end

--- a/lib/reactionview/slots/rendering.rb
+++ b/lib/reactionview/slots/rendering.rb
@@ -5,6 +5,8 @@ require "json"
 module ReActionView
   module Slots
     module Rendering
+      BODY_END_TAG = "</body>"
+
       def _normalize_options(options)
         super
 
@@ -16,13 +18,46 @@ module ReActionView
       def render_to_body(options = {})
         rendered = super
 
-        rendered.is_a?(::Hash) ? ::JSON.generate(rendered) : rendered
+        return ::JSON.generate(rendered) if rendered.is_a?(::Hash)
+
+        deliver_slot_dependencies(rendered, options)
+
+        rendered
       end
 
       private
 
       def slots_request?
         respond_to?(:request) && request&.format&.symbol == Slots::FORMAT
+      end
+
+      def deliver_slot_dependencies(body, options)
+        return if slots_request?
+        return unless body.is_a?(::String)
+        return unless body.include?(Slots::REGION_MARKER)
+
+        entry = entry_point_for(options)
+
+        return unless entry
+
+        Slots.dependencies.deliver(entry)
+      rescue ::StandardError => e
+        logger = defined?(::Rails) && ::Rails.logger
+        logger&.debug { "ReActionView could not build the slot dependency map: #{e.class}: #{e.message}" }
+
+        nil
+      end
+
+      def entry_point_for(options)
+        name = options[:template] || (respond_to?(:action_name) ? action_name : nil)
+
+        return nil unless name
+
+        template = lookup_context.find(name.to_s, options[:prefixes] || _prefixes, false)
+
+        template&.identifier
+      rescue ::ActionView::MissingTemplate
+        nil
       end
     end
   end

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -6,6 +6,7 @@ require "herb/engine/slots/dynamics_compiler"
 
 require "herb/engine/visitors/debug_visitor"
 require "herb/engine/slots/visitor"
+require "herb/engine/slots/dependencies"
 require "herb/engine/visitors/content_for_visitor"
 require "herb/engine/validators"
 
@@ -31,6 +32,10 @@ module ReActionView
           new.call(template, source, validation_mode: validation_mode)
         end
 
+        def self.compile_for_dependencies(source, path)
+          new.compile_for_dependencies(source, path)
+        end
+
         def call(template, source, validation_mode: nil)
           mode = validation_mode || ReActionView.config.validation_mode
 
@@ -52,6 +57,30 @@ module ReActionView
           config[:visitors] = [*visitors, *slot_visitors(template, source)]
 
           erb_implementation.new(source, config).src
+        end
+
+        def compile_for_dependencies(source, path)
+          template = ::Struct.new(:identifier, :format).new(path, :html)
+          visitor = slot_visitors(template, source, mark: false).first
+
+          return nil unless visitor
+
+          visitors = [
+            *validation_visitors(ReActionView.config.validation_mode),
+            *debug_visitors(template),
+            *head_visitors(template),
+            *ReActionView.config.transform_visitors,
+            visitor
+          ]
+
+          erb_implementation.new(
+            source,
+            filename: translate_path_for_editor(path),
+            project_path: ::ReActionView.config.project_path,
+            visitors: visitors
+          ).src
+
+          visitor
         end
 
         private

--- a/test/slots/rendering_test.rb
+++ b/test/slots/rendering_test.rb
@@ -65,6 +65,21 @@ class ReActionView::Slots::RenderingTest < Minitest::Spec
     prepend ReActionView::Slots::Rendering
   end
 
+  class Rendering < Controller
+    prepend ReActionView::Slots::Rendering
+
+    attr_reader :lookup_context, :request
+
+    def initialize(lookup_context, format)
+      super()
+
+      @lookup_context = lookup_context
+      @request = Request.new(Format.new(format))
+    end
+
+    def _prefixes = []
+  end
+
   def render(format, **assigns)
     lookup = ActionView::LookupContext.new(
       [ReActionView::Slots::Resolver.new(@root), ActionView::FileSystemResolver.new(@root)]
@@ -132,6 +147,57 @@ class ReActionView::Slots::RenderingTest < Minitest::Spec
       options = NormalizingWithSlots.new(:html)._normalize_options({})
 
       refute_includes options.keys, :layout
+    end
+  end
+
+  describe "the dependency map a page carries" do
+    def page_body(format, body)
+      lookup = ActionView::LookupContext.new([ReActionView::Slots::Resolver.new(@root), ActionView::FileSystemResolver.new(@root)])
+      lookup.formats = [:html]
+
+      previous = ReActionView.config.instance_variable_get(:@project_path)
+      ReActionView.config.project_path = @root
+      ReActionView::Slots.reset_dependencies!
+
+      Rendering.new(lookup, format).render_to_body(body: body, template: "users/show")
+    ensure
+      ReActionView.config.project_path = previous
+      ReActionView::Slots.reset_dependencies!
+    end
+
+    def slotted_page
+      html = render(:html)
+
+      "<html><body>#{html}</body></html>"
+    end
+
+    def delivered(body)
+      session = ::Herb::Engine::Runtime::Session.capture { page_body(:html, body) }
+
+      session.channel(::Herb::Engine::Slots::Dependencies::Channel::NAME) { nil }
+    end
+
+    test "carries what the page's state reaches" do
+      map = delivered(slotted_page).to_html
+
+      assert_includes map, "<template data-herb-dependencies>"
+      assert_includes map, "@tone"
+      assert_includes map, "@title"
+    end
+
+    test "hands it to the response rather than writing it into the page" do
+      body = page_body(:html, slotted_page)
+
+      refute_includes body, "data-herb-dependencies"
+    end
+
+    test "leaves a page with no slots alone, and hands over nothing" do
+      assert_equal "<html><body><p>plain</p></body></html>", page_body(:html, "<html><body><p>plain</p></body></html>")
+      assert_nil delivered("<html><body><p>plain</p></body></html>")
+    end
+
+    test "leaves a values response alone" do
+      assert_equal "{\"a\":1}", page_body(ReActionView::Slots::FORMAT, { a: 1 })
     end
   end
 end


### PR DESCRIPTION
A page can now be asked for its values, but a client asking for them does not know which of them any given piece of state moves. This pull request hands the page that map.

`ReActionView::Slots.dependencies` builds a `Herb::Engine::Slots::Dependencies` over the project's templates and delivers it alongside a response whose body carries slot markers. The entry point is resolved from the render options, falling back to the action name.

The map is only worth anything if it was built from the same compile the page was. A version is a digest of a template's slots, and the slots depend on every visitor that ran before the slot visitor, so a map built from a bare compile names versions no page carries and the two agree about nothing. `Handlers::Herb.compile_for_dependencies` exists for that, and it assembles validation, debug, head, and configured visitors exactly as a page compile does before handing back the slot visitor that saw them.

The map is held for the process, since building it reads and compiles every template a page renders and a page asks the same question on every request. That makes it stale the moment a template changes, so a file watcher over the view paths drops it on reload, and it also resets when the project path changes underneath it.

Delivery goes to the response through the channel, not into the body. Finding a `</body>` to write before assumes a response has one, and the search would run over a string that is already finished.