### PR TITLE
Put the dev tools wrapper on the class that replaced them

### DIFF
--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,8 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/client": "0.10.3",
-    "@herb-tools/dev-tools": "0.10.3"
+    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@6232d43"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -1,6 +1,6 @@
-import "@herb-tools/client"
+import { HerbDevTools, type HerbDevToolsOptions } from "@herb-tools/dev-tools"
 
-import { initHerbDevTools, HerbOverlay, type HerbDevToolsOptions } from "@herb-tools/dev-tools"
+type HerbOverlay = NonNullable<HerbDevTools["overlay"]>
 
 export interface ReActionViewDevToolsOptions extends HerbDevToolsOptions {
   projectPath?: string
@@ -8,7 +8,7 @@ export interface ReActionViewDevToolsOptions extends HerbDevToolsOptions {
 }
 
 export class ReActionViewDevTools {
-  private herbOverlay: HerbOverlay | null = null
+  private devTools: HerbDevTools | null = null
   private static instance: ReActionViewDevTools | null = null
 
   constructor(private options: ReActionViewDevToolsOptions = {}) {
@@ -17,33 +17,26 @@ export class ReActionViewDevTools {
     }
   }
 
-  init(): HerbOverlay {
-    if (this.herbOverlay) {
-      this.destroy()
-    }
+  init(): HerbDevTools | null {
+    this.destroy()
 
-    this.herbOverlay = initHerbDevTools({
+    HerbDevTools.instance?.stop()
+
+    this.devTools = HerbDevTools.start({
       projectPath: this.options.projectPath,
       ...this.options
     })
 
-    return this.herbOverlay
+    return this.devTools
   }
 
   destroy(): void {
-    if (this.herbOverlay) {
-      const existingMenu = document.querySelector(".herb-floating-menu")
-
-      if (existingMenu) {
-        existingMenu.remove()
-      }
-    }
-
-    this.herbOverlay = null
+    this.devTools?.stop()
+    this.devTools = null
   }
 
   getHerbOverlay(): HerbOverlay | null {
-    return this.herbOverlay
+    return this.devTools?.overlay ?? null
   }
 
   static getInstance(): ReActionViewDevTools | null {
@@ -85,6 +78,10 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
       return
     }
 
+    if (ReActionViewDevTools.getInstance() && HerbDevTools.instance) {
+      return
+    }
+
     isInitializing = true
 
     try {
@@ -118,7 +115,7 @@ declare global {
     ReActionViewDevTools: {
       init: typeof initReActionViewDevTools
       ReActionViewDevTools: typeof ReActionViewDevTools
-      HerbOverlay: typeof HerbOverlay
+      HerbDevTools: typeof HerbDevTools
     }
   }
 }
@@ -127,8 +124,8 @@ if (typeof window !== "undefined") {
   window.ReActionViewDevTools = {
     init: initReActionViewDevTools,
     ReActionViewDevTools,
-    HerbOverlay
+    HerbDevTools
   }
 }
 
-export { HerbOverlay, type HerbDevToolsOptions }
+export { HerbDevTools, type HerbDevToolsOptions }

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,24 +180,48 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@herb-tools/client@0.10.3":
+"@herb-tools/browser@0.10.3":
   version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@herb-tools/client/-/client-0.10.3.tgz#87b01a6d86b50891819624f67184718f21c5e6d4"
-  integrity sha512-0bZCDlrWz9x9d5amgwY28AEcdI4ng7n4W1mDA/bzKO0JZPP66r6zhi3S8g+CWyInOW2QJk1IcfbASe6W6CB7DQ==
+  resolved "https://registry.yarnpkg.com/@herb-tools/browser/-/browser-0.10.3.tgz#bdd7238de68efe76b3ed988bba2b8c6214553931"
+  integrity sha512-5Kz1jEvj/VIeed8cIm4HFcsCdz6jIUO6aTZPW+wGq07k46AtQqwC0BsoxjSelU2gELvHVg9igNybhJkSBemVcQ==
+  dependencies:
+    "@herb-tools/core" "0.10.3"
+    "@ruby/prism" "^1.9.0"
 
-"@herb-tools/core@0.10.3":
+"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@6232d43":
   version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.10.3.tgz#03b1bf1a5d0c5acf9841209cf0c26dae3e2d85bb"
-  integrity sha512-rtDoh6C/EMYLEtFwYpuY+IlnV7PLsF5hQszq7uMDE/bwEpLVBlPFd2Wlk9E0RB31PVQKV1MwgGqstte87XqF9g==
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@6232d43#74e3b05dfa0296eabac57e64520234df080fbd65"
+
+"@herb-tools/core@0.10.3", "@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@6232d43":
+  version "0.10.3"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@6232d43#b76e6f5d8b12052fddc17bbe2d3d621da50532fa"
   dependencies:
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/dev-tools@0.10.3":
+"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@6232d43":
   version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@herb-tools/dev-tools/-/dev-tools-0.10.3.tgz#9f6d1281692079b6cb68ffad2b4dbc65673d18a3"
-  integrity sha512-j0kXJGXDdcYRnci1OImvlViRqnPt+ACpfQbp9tL4EI1Bjtr/HW5oQu1ADuchar7lVKwamBG9L6BEuxOy5tjvmg==
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@6232d43#aaaee5fed3e3b1fedeebf2584c2dc73bd797295f"
+  dependencies:
+    "@herb-tools/browser" "0.10.3"
+    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@6232d43"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@6232d43"
+    "@herb-tools/highlighter" "0.10.3"
+
+"@herb-tools/highlighter@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/highlighter/-/highlighter-0.10.3.tgz#f4b1dfb770e32055a778c4f44847111387efe98c"
+  integrity sha512-vyBPl/oWalPcXrhni6RrQzeizzC0i7An3yMAg/Xx+4HDhgU/zOlRqSUYLU7SpzjfK4OU5QhRDdc3OBI8dT5qmg==
   dependencies:
     "@herb-tools/core" "0.10.3"
+    "@herb-tools/node-wasm" "0.10.3"
+
+"@herb-tools/node-wasm@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@herb-tools/node-wasm/-/node-wasm-0.10.3.tgz#dc1527c2af245f67dbe85e3ba3782aefafc70653"
+  integrity sha512-KUwHUMB6kluyvRiW0A9wbTiuO/qlvXLlSAnewmH2za7yePvYRSiThfAZEmXPqEmpmMRcIksFxaNaxUc6nBqyuA==
+  dependencies:
+    "@herb-tools/core" "0.10.3"
+    "@ruby/prism" "^1.9.0"
 
 "@iconify-json/logos@^1.2.4":
   version "1.2.9"


### PR DESCRIPTION
Herb replaced `initHerbDevTools` and the `HerbOverlay` it returned with a `HerbDevTools` class that owns its own lifecycle, so this pull request moves the ReActionView wrapper onto it.

```diff
-this.herbOverlay = initHerbDevTools({ … })
+this.devTools = HerbDevTools.start({ … })
```

Tearing down used to mean finding `.herb-floating-menu` in the document and removing it, which knew more about the overlay's markup than a wrapper should and left everything else the overlay had attached. `stop()` does it properly. `getHerbOverlay()` still answers, reading through to `devTools.overlay`, so nothing calling it has to change.

Auto initialization gives up early when both the wrapper and `HerbDevTools` are already running. A page that loads the dev tools a second time, which is what the error page in #132 does, would otherwise start a second copy over the first.

`@herb-tools/client` comes off the dependency list. It was imported for its side effect and dev-tools depends on it directly, so naming it here only made it possible for the two to disagree about a version.

The remaining dependency moves off the released packages onto a pkg.pr.new build, so the browser half is built from the same herb the gem tracks rather than from the last release.