### PR TITLE
Never compile the templates Rails renders its own errors from

### DIFF
--- a/lib/reactionview/template/handlers/erb.rb
+++ b/lib/reactionview/template/handlers/erb.rb
@@ -26,6 +26,7 @@ module ReActionView
 
         def intercept_template?(template)
           return false unless template.format == :html && ReActionView.config.intercept_erb
+          return false if framework_template?(template)
 
           local_template?(template) || ReActionView.config.external_template_mode != :skip
         end

--- a/lib/reactionview/template/local_template.rb
+++ b/lib/reactionview/template/local_template.rb
@@ -3,7 +3,15 @@
 module ReActionView
   class Template
     module LocalTemplate
+      FRAMEWORK_TEMPLATE_SEGMENT = "/action_dispatch/middleware/templates/" #: String
+
       private
+
+      def framework_template?(template)
+        return false unless template.respond_to?(:identifier) && template.identifier
+
+        template.identifier.to_s.include?(FRAMEWORK_TEMPLATE_SEGMENT)
+      end
 
       def local_template?(template)
         return true unless template.respond_to?(:identifier) && template.identifier

--- a/test/template/handlers/external_template_mode_test.rb
+++ b/test/template/handlers/external_template_mode_test.rb
@@ -4,7 +4,8 @@ require_relative "../../test_helper"
 
 class ReActionView::ExternalTemplateModeTest < Minitest::Spec
   RAILS_ROOT = "/app"
-  EXTERNAL = "/gems/actionpack-8.1.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb"
+  EXTERNAL = "/gems/devise-4.9.4/app/views/devise/sessions/new.html.erb"
+  FRAMEWORK = "/gems/actionpack-8.1.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb"
   LOCAL = "/app/app/views/users/show.html.erb"
 
   INVALID = %(<p><h2>I am invalid</h2></p>)
@@ -111,6 +112,26 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
     assert_raises(Herb::Engine::CompilationError) do
       compile(INVALID, EXTERNAL)
     end
+  ensure
+    ReActionView.config.validation_mode = nil
+  end
+
+  test "never compiles a template Rails renders its own errors from" do
+    ReActionView.config.external_template_mode = :compile
+
+    compiled = compile(VALID, FRAMEWORK)
+
+    assert_equal ActionView::Template::Handlers::ERB.new.call(build(VALID, FRAMEWORK), VALID), compiled
+    assert_empty @log.string
+  end
+
+  test "leaves it to Rails even when Herb could not have compiled it anyway" do
+    ReActionView.config.external_template_mode = :compile
+    ReActionView.config.validation_mode = :raise
+
+    compiled = compile(INVALID, FRAMEWORK)
+
+    assert_equal ActionView::Template::Handlers::ERB.new.call(build(INVALID, FRAMEWORK), INVALID), compiled
   ensure
     ReActionView.config.validation_mode = nil
   end


### PR DESCRIPTION
Rails ships the templates it renders its own error pages from, and `external_template_mode: :compile` was treating them as ordinary gem templates.

They are the last thing standing when something else has already failed. Putting Herb in the path of the page whose only job is to explain what went wrong means a template Herb cannot compile replaces the error someone actually hit with one about the error page. The handler now recognizes them by the path Rails renders them from and leaves them to the handler Rails wrote them for, whatever `external_template_mode` says about gem templates in general.

Both directions are covered. A valid rescue template compiles as Rails' own ERB and logs nothing, and an invalid one does the same under `validation_mode: :raise`, which is the case worth having, since that is when compiling one would otherwise have raised.

The test file's own idea of an external template was a rescue template, so `EXTERNAL` now points at a real third party view and `FRAMEWORK` covers the rescue path it used to name.