### PR TITLE
Track herb's main branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "appraisal"
-# gem "herb", path: "../herb"
+gem "herb", github: "marcoroth/herb", branch: "main"
+
 gem "actionview", "~> 8.1"
+gem "appraisal"
 gem "maxitest", "~> 7.0"
 gem "minitest-difftastic"
 gem "minitest-mock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
 PATH
   remote: .
   specs:
@@ -72,14 +87,6 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -211,6 +218,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (~> 8.1)
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "herb", github: "marcoroth/herb", branch: "main"
 gem "actionview", "~> 7.0.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
 PATH
   remote: ..
   specs:
@@ -68,14 +83,6 @@ GEM
       prism
     drb (2.2.3)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -183,6 +190,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (~> 7.0.0)
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "herb", github: "marcoroth/herb", branch: "main"
 gem "actionview", "~> 7.1.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
 PATH
   remote: ..
   specs:
@@ -76,14 +91,6 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -215,6 +222,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (~> 7.1.0)
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "herb", github: "marcoroth/herb", branch: "main"
 gem "actionview", "~> 7.2.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
 PATH
   remote: ..
   specs:
@@ -76,14 +91,6 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -215,6 +222,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (~> 7.2.0)
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "herb", github: "marcoroth/herb", branch: "main"
 gem "actionview", "~> 8.0.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
 PATH
   remote: ..
   specs:
@@ -73,14 +88,6 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -212,6 +219,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (~> 8.0.0)
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "herb", github: "marcoroth/herb", branch: "main"
 gem "actionview", "~> 8.1.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
 PATH
   remote: ..
   specs:
@@ -72,14 +87,6 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -211,6 +218,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (~> 8.1.0)
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/gemfiles/rails_8_2.gemfile
+++ b/gemfiles/rails_8_2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "herb", github: "marcoroth/herb", branch: "main"
 gem "actionview", github: "rails/rails"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -1,4 +1,19 @@
 GIT
+  remote: https://github.com/marcoroth/herb.git
+  revision: cf08361ca5a56f2f9509cf8ad30ea7d9c8a23d9f
+  branch: main
+  specs:
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-aarch64-linux-musl)
+    herb (0.10.3-arm-linux-gnu)
+    herb (0.10.3-arm-linux-musl)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
+    herb (0.10.3-x86_64-linux-musl)
+
+GIT
   remote: https://github.com/rails/rails.git
   revision: 5ea765e5b00085a22f5cbe863c0d2ac765428242
   specs:
@@ -89,14 +104,6 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -224,6 +231,7 @@ PLATFORMS
 DEPENDENCIES
   actionview!
   appraisal
+  herb!
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock

--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -65,7 +65,9 @@ module ReActionView
       return @dev_server_port if @dev_server_port
       return nil unless development?
 
-      ::Herb.dev_server_port(Rails.root.to_s)
+      require "herb/dev/server_entry"
+
+      ::Herb::Dev::ServerEntry.port_for(Rails.root.to_s)
     end
   end
 

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require "herb"
+require "herb/engine"
+
+require "herb/engine/visitors/debug_visitor"
+require "herb/engine/visitors/content_for_visitor"
+require "herb/engine/validators"
+
 module ReActionView
   class Template
     module Handlers
@@ -15,27 +22,47 @@ module ReActionView
         end
 
         def call(template, source, validation_mode: nil)
-          visitors = []
+          mode = validation_mode || ReActionView.config.validation_mode
 
-          if ::ReActionView.config.debug_mode_enabled? && local_template?(template)
-            visitors << ::Herb::Engine::DebugVisitor.new(
-              file_path: translate_path_for_editor(template.identifier),
-              project_path: ::ReActionView.config.project_path
-            )
-          end
+          visitors = [
+            *validation_visitors(mode),
+            *debug_visitors(template),
+            *head_visitors(template),
+            *ReActionView.config.transform_visitors
+          ]
 
           config = {
-            filename: template.identifier,
-            project_path: Rails.root.to_s,
-            validation_mode: validation_mode || ReActionView.config.validation_mode,
-            content_for_head: reactionview_dev_tools_markup(template),
-            visitors: visitors + ReActionView.config.transform_visitors,
+            filename: translate_path_for_editor(template.identifier),
+            project_path: ::ReActionView.config.project_path,
+            visitors: visitors,
           }
 
           erb_implementation.new(source, config).src
         end
 
         private
+
+        def validation_visitors(mode)
+          case mode
+          when :raise then ::Herb::Engine::Validators.all(fatal: true).to_a
+          when :overlay then ::Herb::Engine::Validators.all(fatal: false).to_a
+          else []
+          end
+        end
+
+        def debug_visitors(template)
+          return [] unless ::ReActionView.config.debug_mode_enabled? && local_template?(template)
+
+          [::Herb::Engine::DebugVisitor.new]
+        end
+
+        def head_visitors(template)
+          markup = reactionview_dev_tools_markup(template)
+
+          return [] if markup.nil? || markup.empty?
+
+          [::Herb::Engine::ContentForVisitor.new(markup, tag_name: "head")]
+        end
 
         def layout_template?(template)
           return false unless template.respond_to?(:identifier) && template.identifier

--- a/test/reactionview/config_test.rb
+++ b/test/reactionview/config_test.rb
@@ -124,11 +124,14 @@ class ReActionView::ConfigTest < Minitest::Spec
   private
 
   def with_detected_dev_server_port(port)
+    require "herb/dev/server_entry"
+
     calls = []
-    original = ::Herb.method(:dev_server_port)
+    entry = ::Herb::Dev::ServerEntry
+    original = entry.method(:port_for)
 
     silence_warnings do
-      ::Herb.define_singleton_method(:dev_server_port) do |project_path = nil|
+      entry.define_singleton_method(:port_for) do |project_path = nil|
         calls << project_path
 
         port
@@ -137,7 +140,7 @@ class ReActionView::ConfigTest < Minitest::Spec
 
     yield calls
   ensure
-    silence_warnings { ::Herb.define_singleton_method(:dev_server_port, original) }
+    silence_warnings { entry.define_singleton_method(:port_for, original) }
   end
 
   def silence_warnings

--- a/test/snapshots/herb/template_handler_test/test_0025_canvas_with_boolean_array_and_multiple_attributes_compiled_3a6660c58ab156795350bc91517160ad.txt
+++ b/test/snapshots/herb/template_handler_test/test_0025_canvas_with_boolean_array_and_multiple_attributes_compiled_3a6660c58ab156795350bc91517160ad.txt
@@ -1,9 +1,9 @@
  @output_buffer.safe_append='<canvas
-data-controller="chart"
-data-chart-unit-type-value="'.freeze; @output_buffer.append=(@unit_type); @output_buffer.safe_append='"
-data-chart-data-value="'.freeze; @output_buffer.append=(@data.to_json); @output_buffer.safe_append='"
-data-chart-labels-value="'.freeze; @output_buffer.append=(@labels.to_json); @output_buffer.safe_append='"
-data-chart-unit-value="'.freeze; @output_buffer.append=(@unit_label); @output_buffer.safe_append='"
+  data-controller="chart"
+  data-chart-unit-type-value="'.freeze; @output_buffer.append=(@unit_type); @output_buffer.safe_append='"
+  data-chart-data-value="'.freeze; @output_buffer.append=(@data.to_json); @output_buffer.safe_append='"
+  data-chart-labels-value="'.freeze; @output_buffer.append=(@labels.to_json); @output_buffer.safe_append='"
+  data-chart-unit-value="'.freeze; @output_buffer.append=(@unit_label); @output_buffer.safe_append='"
 ></canvas>
 '.freeze;
 @output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0025_canvas_with_boolean_array_and_multiple_attributes_evaluated_95ae40fdfac81fcfee0bca6f6cf55d7a.txt
+++ b/test/snapshots/herb/template_handler_test/test_0025_canvas_with_boolean_array_and_multiple_attributes_evaluated_95ae40fdfac81fcfee0bca6f6cf55d7a.txt
@@ -1,7 +1,7 @@
 <canvas
-data-controller="chart"
-data-chart-unit-type-value="yes/no"
-data-chart-data-value="[true,true,true,true,true,true]"
-data-chart-labels-value="[&quot;2025-05-16&quot;,&quot;2025-05-17&quot;,&quot;2025-05-19&quot;,&quot;2025-05-20&quot;,&quot;2025-07-28&quot;,&quot;2025-09-12&quot;]"
-data-chart-unit-value="sessions"
+  data-controller="chart"
+  data-chart-unit-type-value="yes/no"
+  data-chart-data-value="[true,true,true,true,true,true]"
+  data-chart-labels-value="[&quot;2025-05-16&quot;,&quot;2025-05-17&quot;,&quot;2025-05-19&quot;,&quot;2025-05-20&quot;,&quot;2025-07-28&quot;,&quot;2025-09-12&quot;]"
+  data-chart-unit-value="sessions"
 ></canvas>

--- a/test/template/handlers/external_template_mode_test.rb
+++ b/test/template/handlers/external_template_mode_test.rb
@@ -142,7 +142,7 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
 
     compiled = compile(INVALID, EXTERNAL)
 
-    assert_includes compiled, "data-herb-validation-error"
+    assert_includes compiled, "record_compile_diagnostics"
     assert_empty @log.string
   ensure
     ReActionView.config.validation_mode = nil
@@ -165,7 +165,7 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
       ReActionView::Template::Handlers::Herb.call(template, INVALID)
     end
 
-    assert_includes compiled, "data-herb-validation-error"
+    assert_includes compiled, "record_compile_diagnostics"
   ensure
     ReActionView.config.validation_mode = nil
   end

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -21,8 +21,11 @@ class Herb::TemplateHandlerTest < Minitest::Spec
   test "error for invalid html" do
     template = "Plain text: <%= 1 + 1 %> (<with_an_invalid_bracket>)"
 
-    assert_compiled_snapshot(template, format: :html)
-    assert_evaluated_snapshot(template, format: :html, ivars: { name: "User" })
+    error = assert_raises(::Herb::Engine::ParseError) do
+      assert_compiled_snapshot(template, format: :html)
+    end
+
+    assert_match(/MissingClosingTag/, error.detailed_message)
   end
 
   test "template with expression" do

--- a/test/template/handlers/project_path_test.rb
+++ b/test/template/handlers/project_path_test.rb
@@ -64,8 +64,8 @@ class ReActionView::ProjectPathTest < Minitest::Spec
 
     compiled = compile("<html><head></head><body></body></html>", identifier: LAYOUT, virtual_path: "layouts/application")
 
-    assert_includes compiled, %(<meta name="herb-project-path" content="/app">)
-    refute_includes compiled, %(<meta name="herb-project-path" content="#{HOST_PATH}">)
+    assert_includes compiled, %(<meta name="herb-project-path" content="/app">).dump[1..-2]
+    refute_includes compiled, %(<meta name="herb-project-path" content="#{HOST_PATH}">).dump[1..-2]
   end
 
   test "templates outside Rails.root stay undecorated even when project_path matches them" do


### PR DESCRIPTION
The gem came off the released version and onto `main`, and the pieces this uses moved while it sat there.

`Herb.dev_server_port` is `Herb::Dev::ServerEntry.port_for`. The engine no longer takes `validation_mode:` or `content_for_head:`, so a validation mode becomes the validators it stands for and the dev tools markup becomes a `ContentForVisitor` aimed at `head`. `DebugVisitor` reads the file and project path off the compile instead of being handed them, which is why the compile passes the editor-translated filename now.

Three tests were asserting on output herb has changed. Invalid HTML raises where it used to compile, a validation finding is recorded through `record_compile_diagnostics` instead of a `data-herb-validation-error` attribute, and compiled source arrives escaped. The two snapshots are regenerated for the same reason.