### PR TITLE
Drain the diagnostics a validated template records

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -31,6 +31,14 @@ module ReActionView
       app.middleware.use ReActionView::Middleware::AssetManifestCheck
     end
 
+    initializer "reactionview.diagnostics" do |app|
+      next unless ReActionView.config.debug_mode_enabled? || ReActionView.config.validation_mode == :overlay
+
+      require "herb/engine/runtime/middleware"
+
+      app.middleware.use ::Herb::Engine::Runtime::Middleware
+    end
+
     initializer "reactionview.register_herb_handler" do
       ActiveSupport.on_load(:action_view) do
         ActionView::Template.register_template_handler :herb, ReActionView::Template::Handlers::Herb


### PR DESCRIPTION
A template compiled in `:overlay` mode used to carry what its validators found as markup in the page. It records the findings through the runtime session now, and nothing here was draining that session, so every overlay finding since the move onto herb's main branch has gone nowhere.

`Herb::Engine::Runtime::Middleware` collects them per request and hands them to the browser as one payload. It mounts whenever debug mode is on or validation is set to overlay, which are the two ways a finding gets recorded in the first place.
