### PR TITLE
Serve a page of its own when a template fails to compile

### DIFF
--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -39,6 +39,22 @@ module ReActionView
       app.middleware.use ::Herb::Engine::Runtime::Middleware
     end
 
+    initializer "reactionview.error_page", after: :load_config_initializers do |app|
+      next unless ReActionView.config.development?
+
+      require "herb/engine/runtime/error_page"
+
+      app.middleware.use(
+        ::Herb::Engine::Runtime::ErrorPage,
+        dev_tools: -> { ReActionView::Railtie.dev_tools_module_path },
+        dev_server_port: -> { ReActionView.config.dev_server_port }
+      )
+    end
+
+    def self.dev_tools_module_path
+      ActionController::Base.helpers.asset_path("reactionview-dev-tools.esm.js")
+    end
+
     initializer "reactionview.register_herb_handler" do
       ActiveSupport.on_load(:action_view) do
         ActionView::Template.register_template_handler :herb, ReActionView::Template::Handlers::Herb


### PR DESCRIPTION
A template that fails to compile leaves no page behind. There is nothing for the diagnostics middleware to inject into and nothing for the dev tools to attach to, so what reaches the browser is whatever Rails renders for an exception, carrying none of what herb knows about the failure.

`Herb::Engine::Runtime::ErrorPage` serves a document of its own with that payload in it. It mounts outside the diagnostics middleware, since the response it builds is its own rather than one to inject into, and only in development.
