### PR TITLE
Allow `debug_mode` to decide per request

### DIFF
--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -78,9 +78,21 @@ module ReActionView
     end
 
     def debug_mode_enabled?
-      return @debug_mode unless @debug_mode.nil?
+      return true if debug_mode_callable?
+      return !!@debug_mode unless @debug_mode.nil?
 
       development?
+    end
+
+    def debug_mode_for_request?(request)
+      return debug_mode_enabled? unless debug_mode_callable?
+      return false if request.nil?
+
+      !!@debug_mode.call(request)
+    end
+
+    def debug_mode_callable?
+      @debug_mode.respond_to?(:call)
     end
 
     def dev_server_port

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -8,6 +8,7 @@ require "herb/engine/visitors/debug_visitor"
 require "herb/engine/slots/visitor"
 require "herb/engine/slots/dependencies"
 require "herb/engine/visitors/content_for_visitor"
+require "reactionview/template/visitors/conditional_content_for_visitor"
 require "herb/engine/validators"
 
 module ReActionView
@@ -19,6 +20,8 @@ module ReActionView
         autoload :Herb, "reactionview/template/handlers/herb/herb"
 
         class_attribute :erb_implementation, default: Handlers::Herb::Herb
+
+        DEBUG_MODE_CONDITION = "::ReActionView.config.debug_mode_for_request?(defined?(request) ? request : nil)" #: String
 
         VALUES_ESCAPING = {
           escape: true,
@@ -116,7 +119,15 @@ module ReActionView
 
           return [] if markup.nil? || markup.empty?
 
-          [::Herb::Engine::ContentForVisitor.new(markup, tag_name: "head")]
+          return [::Herb::Engine::ContentForVisitor.new(markup, tag_name: "head")] unless ::ReActionView.config.debug_mode_callable?
+
+          [
+            ::ReActionView::Template::Visitors::ConditionalContentForVisitor.new(
+              markup,
+              tag_name: "head",
+              condition: DEBUG_MODE_CONDITION
+            )
+          ]
         end
 
         def slot_visitors(template, source, mark: true)

--- a/lib/reactionview/template/visitors/conditional_content_for_visitor.rb
+++ b/lib/reactionview/template/visitors/conditional_content_for_visitor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "herb/engine/visitors/content_for_visitor"
+
+module ReActionView
+  class Template
+    module Visitors
+      # Emits content behind a render-time condition, so a cached compiled
+      # template can still decide per request. +condition+ is Ruby source
+      # evaluated in the view context and must never come from user input.
+      class ConditionalContentForVisitor < ::Herb::Engine::ContentForVisitor
+        #: (String?, tag_name: String, condition: String, ?attributes: Hash[untyped, untyped]) -> void
+        def initialize(content, tag_name:, condition:, attributes: {})
+          super(content, tag_name: tag_name, attributes: attributes)
+
+          @condition = condition
+        end
+
+        private
+
+        #: () -> Herb::AST::RubyLiteralNode
+        def content_node
+          ::Herb::AST::RubyLiteralNode.build(
+            content: "((#{@condition}) ? #{@content.dump}.html_safe : \"\")"
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/template/handlers/dev_tools_markup_test.rb
+++ b/test/template/handlers/dev_tools_markup_test.rb
@@ -92,4 +92,87 @@ class ReActionView::DevToolsMarkupTest < Minitest::Spec
     refute_includes compiled, DISMISS_HINT
     refute_includes compiled, "herb-debug-mode"
   end
+
+  REQUEST = Struct.new(:user_agent)
+
+  class RenderContext
+    attr_reader :output_buffer
+
+    attr_reader :request
+
+    def initialize(request)
+      @request = request
+      @output_buffer = ActionView::OutputBuffer.new
+    end
+
+    def method_missing(*) = ""
+
+    def respond_to_missing?(*) = true
+  end
+
+  def render(compiled, user_agent)
+    context = RenderContext.new(REQUEST.new(user_agent))
+    context.instance_eval(compiled)
+    context.output_buffer.to_s
+  end
+
+  test "compiles a render-time condition when debug mode is a callable" do
+    ReActionView.config.debug_mode = ->(_request) { true }
+
+    assert_includes compile, "debug_mode_for_request?"
+  end
+
+  test "a callable debug mode decides per request from one compiled template" do
+    ReActionView.config.debug_mode = ->(request) { !request.user_agent.to_s.include?("Hotwire Native") }
+
+    compiled = compile
+
+    assert_includes render(compiled, "Mozilla/5.0"), "herb-debug-mode"
+    refute_includes render(compiled, "MyApp Hotwire Native iOS"), "herb-debug-mode"
+  end
+
+  test "a callable returning a non-boolean is evaluated for truthiness" do
+    ReActionView.config.debug_mode = ->(request) { request.user_agent.presence }
+
+    compiled = compile
+
+    assert_includes render(compiled, "Mozilla/5.0"), "herb-debug-mode"
+    refute_includes render(compiled, ""), "herb-debug-mode"
+  end
+
+  test "a callable is not invoked when there is no request" do
+    ReActionView.config.debug_mode = ->(request) { request.user_agent.include?("nope") }
+
+    refute ReActionView.config.debug_mode_for_request?(nil)
+  end
+
+  test "debug_mode_enabled? assumes enabled for a callable so boot-time hooks still install" do
+    ReActionView.config.debug_mode = ->(_request) { false }
+
+    assert ReActionView.config.debug_mode_enabled?
+  end
+
+  test "a non-callable truthy value is evaluated for truthiness" do
+    ReActionView.config.debug_mode = "yes"
+
+    assert ReActionView.config.debug_mode_enabled?
+    assert_includes compile, "herb-debug-mode"
+  end
+
+  test "non-callable values still compile a static tag with no render-time condition" do
+    ReActionView.config.debug_mode = true
+
+    compiled = compile
+
+    assert_includes compiled, "herb-debug-mode"
+    refute_includes compiled, "debug_mode_for_request?"
+  end
+
+  test "debug_mode_for_request? falls back to the static value for non-callables" do
+    ReActionView.config.debug_mode = true
+    assert ReActionView.config.debug_mode_for_request?(nil)
+
+    ReActionView.config.debug_mode = false
+    refute ReActionView.config.debug_mode_for_request?(nil)
+  end
 end


### PR DESCRIPTION
Hotwire Native apps render the same layouts as the web app, so the Herb debug tools button shows up inside the native app where it isn't wanted. There was no way to keep it on the web and hide it there.

`debug_mode` now also accepts a callable, which receives the request:

```ruby
ReActionView.configure do |config|
  config.debug_mode = ->(request) { !request.user_agent.to_s.include?("Hotwire Native") }
end
```

Anything that isn't callable keeps its existing meaning and is evaluated for truthiness, so `true`, `false` and `Rails.env.development?` behave exactly as before, and `nil` still falls back to `development?`.

Templates are compiled once and cached, so `reactionview_dev_tools_markup` can't answer a per-request question at compile time. `ContentForVisitor` bakes its content in as a frozen literal, and it dumps that content, so a condition can't be smuggled in through the markup either.

`ConditionalContentForVisitor` overrides `content_node` to emit a ternary instead, which leaves the decision to render time while the compiled template stays cached:

```ruby
_buf << (((condition) ? "...markup...".html_safe : "")).to_s
```

Only a callable `debug_mode` compiles that condition. Every other value still compiles the same static markup as before.

`debug_mode_enabled?` reports `true` for a callable because the railtie asks at boot, before any request exists, and the assets and middleware have to be installed for a later request that does enable debug mode. `debug_mode_for_request?` gives the real answer at render time, and returns `false` when there is no request, so callables don't have to guard against a `nil` in mailers and standalone renders.

The `data-herb-*` attributes are still emitted at compile time. They are inert without the dev tools script, which the condition withholds.

Resolves #105

If you're curious, here's what it looks like on web and native with this change

<img height="300" alt="Screenshot 2026-08-30 at 11 35 41 PM" src="https://github.com/user-attachments/assets/34252c73-0ec1-40db-a5eb-4fa8c815f969" />

<img height="300" alt="Screenshot 2026-08-30 at 11 35 49 PM" src="https://github.com/user-attachments/assets/e18fa3a8-0bc0-42f8-9a47-0a52fa6599fd" />


