### PR TITLE
Integrate the Herb dev server for slot-aware hot reload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 4e8fd5aab8e1d7657c55462cdf71b10b42b5c9c0
+  revision: 7598e6daf0a8d048cbba1e7087fb8a7a04219f57
   branch: main
   specs:
     herb (0.10.3)

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@main"
+    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@7598e6d"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/lib/reactionview.rb
+++ b/lib/reactionview.rb
@@ -20,6 +20,7 @@ require_relative "reactionview/config"
 require_relative "reactionview/slots"
 require_relative "reactionview/slots/resolver"
 require_relative "reactionview/slots/rendering"
+require_relative "reactionview/slots/dev_compiler"
 
 require_relative "reactionview/template/local_template"
 

--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -11,6 +11,7 @@ module ReActionView
 
     attr_reader :slots
 
+    attr_writer :dev_server
     attr_writer :dev_server_port
     attr_writer :project_path
     attr_writer :validation_mode
@@ -18,11 +19,18 @@ module ReActionView
     def initialize
       @intercept_erb = false
       @debug_mode = nil
+      @dev_server = nil
       @dev_server_port = nil
       @external_template_mode = nil
       @transform_visitors = []
       @project_path = nil
       @slots = false
+    end
+
+    def dev_server_enabled?
+      return @dev_server unless @dev_server.nil?
+
+      true
     end
 
     def slots=(value)

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -32,7 +32,7 @@ module ReActionView
     end
 
     initializer "reactionview.diagnostics" do |app|
-      next unless ReActionView.config.debug_mode_enabled? || ReActionView.config.validation_mode == :overlay
+      next unless ReActionView.config.debug_mode_enabled? || ReActionView.config.validation_mode == :overlay || ReActionView.config.slots
 
       require "herb/engine/runtime/middleware"
 
@@ -82,6 +82,35 @@ module ReActionView
 
       app.reloaders << watcher
       app.reloader.to_run { watcher.execute_if_updated }
+    end
+
+    initializer "reactionview.slots.dev_server", after: :load_config_initializers do |app|
+      next unless ReActionView.config.slots
+      next unless ReActionView.config.development?
+      next unless ReActionView.config.dev_server_enabled?
+
+      begin
+        require "herb/dev"
+      rescue LoadError
+        next
+      end
+
+      ::Herb::Dev.compiler = ReActionView::Slots::DevCompiler.new
+
+      app.server { Railtie.boot_dev_server }
+    end
+
+    def self.boot_dev_server
+      embedded = ::Herb::Dev.boot(
+        ReActionView.config.project_path,
+        logger: ->(message) { Rails.logger.info("[Herb Dev Server] #{message}") }
+      )
+
+      if embedded
+        $stdout.puts "* Herb Dev Server: ws://localhost:#{embedded.server.port} (embedded)"
+      else
+        $stdout.puts "* Herb Dev Server: not started, see the log"
+      end
     end
 
     initializer "reactionview.register_herb_handler" do

--- a/lib/reactionview/slots/dev_compiler.rb
+++ b/lib/reactionview/slots/dev_compiler.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ReActionView
+  module Slots
+    # Compiles one template for the Herb dev server, the way the application would.
+    #
+    # The dev server's watcher calls this from its own thread whenever a template changes, so
+    # the compile runs inside the Rails executor for autoload and reloader safety. A raise is
+    # left to the caller, which turns it into diagnostics instead of crashing the thread.
+    #
+    class DevCompiler
+      def call(source, relative_path)
+        absolute = File.expand_path(relative_path, ReActionView.config.project_path)
+
+        result = Rails.application.executor.wrap do
+          ReActionView::Template::Handlers::Herb.compile_for_schema(source, absolute)
+        end
+
+        ReActionView::Slots.reset_dependencies!
+
+        result
+      end
+    end
+  end
+end

--- a/lib/reactionview/slots/rendering.rb
+++ b/lib/reactionview/slots/rendering.rb
@@ -16,9 +16,15 @@ module ReActionView
       end
 
       def render_to_body(options = {})
-        rendered = super
+        begin
+          rendered = super
+        rescue ::StandardError => e
+          raise unless slots_request? && ReActionView.config.development?
 
-        return ::JSON.generate(rendered) if rendered.is_a?(::Hash)
+          return render_slots_error(e)
+        end
+
+        return ::JSON.generate(merge_schema(rendered, options)) if rendered.is_a?(::Hash)
 
         deliver_slot_dependencies(rendered, options)
 
@@ -26,6 +32,44 @@ module ReActionView
       end
 
       private
+
+      def render_slots_error(error)
+        self.status = 500
+
+        cause = error.cause || error
+        template = error.respond_to?(:template) && error.template
+
+        entry = {
+          class: cause.class.name,
+          message: cause.message,
+          template: template.respond_to?(:short_identifier) ? template.short_identifier : nil,
+        }
+
+        ::JSON.generate({ error: entry })
+      end
+
+      def merge_schema(rendered, options)
+        return rendered unless request&.headers&.[]("Herb-Schema").present?
+
+        entry = entry_point_for(options)
+
+        return rendered unless entry
+
+        schema = ReActionView::Template::Handlers::Herb.compile_for_schema(::File.read(entry), entry)
+
+        rendered.merge(schema: {
+          mode: schema.mode,
+          version: schema.version,
+          manifest: schema.manifest,
+          static_markup: schema.static_markup,
+          statics: schema.statics,
+        })
+      rescue ::StandardError => e
+        logger = defined?(::Rails) && ::Rails.logger
+        logger&.debug { "ReActionView could not build the schema envelope: #{e.class}: #{e.message}" }
+
+        rendered
+      end
 
       def slots_request?
         respond_to?(:request) && request&.format&.symbol == Slots::FORMAT

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -3,6 +3,7 @@
 require "herb"
 require "herb/engine"
 require "herb/engine/slots/dynamics_compiler"
+require "herb/engine/slots/schema_compiler"
 
 require "herb/engine/visitors/debug_visitor"
 require "herb/engine/slots/visitor"
@@ -36,15 +37,14 @@ module ReActionView
           new.compile_for_dependencies(source, path)
         end
 
+        def self.compile_for_schema(source, path)
+          new.compile_for_schema(source, path)
+        end
+
         def call(template, source, validation_mode: nil)
           mode = validation_mode || ReActionView.config.validation_mode
 
-          visitors = [
-            *validation_visitors(mode),
-            *debug_visitors(template),
-            *head_visitors(template),
-            *ReActionView.config.transform_visitors
-          ]
+          visitors = base_visitors(template, validation_mode: mode)
 
           config = {
             filename: translate_path_for_editor(template.identifier),
@@ -65,25 +65,43 @@ module ReActionView
 
           return nil unless visitor
 
-          visitors = [
-            *validation_visitors(ReActionView.config.validation_mode),
-            *debug_visitors(template),
-            *head_visitors(template),
-            *ReActionView.config.transform_visitors,
-            visitor
-          ]
-
           erb_implementation.new(
             source,
             filename: translate_path_for_editor(path),
             project_path: ::ReActionView.config.project_path,
-            visitors: visitors
+            visitors: [*base_visitors(template), visitor]
           ).src
 
           visitor
         end
 
+        def compile_for_schema(source, path)
+          template = ::Struct.new(:identifier, :format).new(path, :html)
+
+          ::Herb::Engine::Slots::SchemaCompiler.call(
+            source,
+            filename: translate_path_for_editor(path),
+            mode: ::ReActionView.config.slot_mode_for(source),
+            visitors: -> { base_visitors(template, validation_mode: schema_validation_mode) },
+            engine: erb_implementation,
+            options: { project_path: ::ReActionView.config.project_path }
+          )
+        end
+
         private
+
+        def base_visitors(template, validation_mode: ReActionView.config.validation_mode)
+          [
+            *validation_visitors(validation_mode),
+            *debug_visitors(template),
+            *head_visitors(template),
+            *ReActionView.config.transform_visitors
+          ]
+        end
+
+        def schema_validation_mode
+          ReActionView.config.validation_mode == :none ? :none : :overlay
+        end
 
         def values_source(template, source, config)
           visitor = slot_visitors(template, source, mark: false).first
@@ -168,9 +186,9 @@ module ReActionView
         end
 
         def reactionview_dev_tools_markup(template)
-          return nil unless ::ReActionView.config.debug_mode_enabled?
           return nil unless layout_template?(template)
           return nil unless local_template?(template)
+          return slots_meta_markup unless ::ReActionView.config.debug_mode_enabled?
 
           <<~HTML
             <meta name="herb-debug-mode" content="true">
@@ -180,6 +198,15 @@ module ReActionView
 
             #{ActionController::Base.new.view_context.javascript_include_tag "reactionview-dev-tools.umd.js", defer: true}
             #{dismiss_hint_template}
+          HTML
+        end
+
+        def slots_meta_markup
+          return nil unless ::ReActionView.config.slots && ::ReActionView.config.development?
+
+          <<~HTML
+            <meta name="herb-project-path" content="#{Rails.root}">
+            #{dev_server_port_meta_tag}
           HTML
         end
 

--- a/test/reactionview/config_test.rb
+++ b/test/reactionview/config_test.rb
@@ -59,6 +59,17 @@ class ReActionView::ConfigTest < Minitest::Spec
     assert_equal :raise, config.validation_mode
   end
 
+  test "the dev server is on by default" do
+    assert_predicate ReActionView::Config.new, :dev_server_enabled?
+  end
+
+  test "the dev server can be switched off" do
+    config = ReActionView::Config.new
+    config.dev_server = false
+
+    refute_predicate config, :dev_server_enabled?
+  end
+
   test "project_path defaults to Rails.root" do
     config = ReActionView::Config.new
 

--- a/test/slots/schema_pull_test.rb
+++ b/test/slots/schema_pull_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "action_controller"
+require "rack/mock"
+require "tmpdir"
+
+class ReActionView::Slots::SchemaPullTest < Minitest::Spec
+  SOURCE = <<~ERB
+    <%# herb:slots client %>
+    <p>Hello, <%= @name %></p>
+  ERB
+
+  class GreetingsController < ActionController::Base
+    prepend ReActionView::Slots::Rendering
+
+    def self.controller_path = "greetings"
+
+    def show
+      @name = "Marco"
+
+      respond_to do |format|
+        format.slots { render :show }
+        format.html { render :show }
+      end
+    end
+  end
+
+  before do
+    @previous = [ReActionView.config.slots, ReActionView.config.intercept_erb, ReActionView.config.debug_mode]
+
+    ReActionView.config.slots = true
+    ReActionView.config.intercept_erb = true
+    ReActionView.config.debug_mode = false
+
+    ActionView::Template.register_template_handler :erb, ReActionView::Template::Handlers::ERB
+    Mime::Type.register(ReActionView::Slots::MIME_TYPE, ReActionView::Slots::FORMAT) unless Mime[ReActionView::Slots::FORMAT]
+  end
+
+  after do
+    ReActionView.config.slots, ReActionView.config.intercept_erb, ReActionView.config.debug_mode = @previous
+
+    ActionView::Template.register_template_handler :erb, ActionView::Template::Handlers::ERB
+  end
+
+  around do |work|
+    Dir.mktmpdir do |root|
+      FileUtils.mkdir_p(File.join(root, "greetings"))
+      File.write(File.join(root, "greetings", "show.html.erb"), SOURCE)
+
+      GreetingsController.view_paths = [
+        ReActionView::Slots::Resolver.new(root),
+        ActionView::FileSystemResolver.new(root)
+      ]
+
+      work.call
+    end
+  end
+
+  def dispatch(headers: {})
+    env = Rack::MockRequest.env_for("/greetings", method: "GET")
+    env["HTTP_ACCEPT"] = ReActionView::Slots::MIME_TYPE
+    headers.each { |name, value| env["HTTP_#{name.upcase.tr("-", "_")}"] = value }
+
+    status, _response_headers, body = GreetingsController.action(:show).call(env)
+    payload = +""
+    body.each { |chunk| payload << chunk }
+
+    [status, JSON.parse(payload)]
+  end
+
+  it "answers values without schema by default" do
+    status, payload = dispatch
+
+    assert_equal 200, status
+    assert payload.key?("slots")
+    refute payload.key?("schema")
+  end
+
+  it "merges the schema envelope when the request asks for it" do
+    _status, payload = dispatch(headers: { "Herb-Schema" => "1" })
+
+    schema = payload.fetch("schema")
+
+    assert_equal "client", schema["mode"]
+    assert_equal payload["version"], schema["version"]
+    assert schema["manifest"].key?("states") || schema["manifest"].key?("names")
+    assert_includes schema["static_markup"], "herb-slot:0"
+  end
+
+  it "answers the same values either way" do
+    _status, plain = dispatch
+    _status, with_schema = dispatch(headers: { "Herb-Schema" => "1" })
+
+    assert_equal plain["slots"], with_schema["slots"]
+    assert_equal plain["version"], with_schema["version"]
+  end
+end

--- a/test/snapshots/herb/template_handler_test/test_0031_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_compiled_ffc55de9e7891578a81f0a2b0c1346a5.txt
+++ b/test/snapshots/herb/template_handler_test/test_0031_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_compiled_ffc55de9e7891578a81f0a2b0c1346a5.txt
@@ -3,6 +3,6 @@
     field
   }
 GRAPHQL
-); @output_buffer.safe_append='
-'.freeze; 
-@output_buffer
+);
+ @output_buffer.safe_append='
+'.freeze;@output_buffer

--- a/test/template/handlers/schema_test.rb
+++ b/test/template/handlers/schema_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+require "action_controller"
+
+class ReActionView::SchemaTest < Minitest::Spec
+  RAILS_ROOT = "/app"
+  VIEW = "/app/app/views/users/show.html.erb"
+
+  before do
+    @previous_slots = ReActionView.config.slots
+
+    ReActionView.config.debug_mode = false
+    ReActionView.config.slots = :client
+  end
+
+  after do
+    ReActionView.config.slots = @previous_slots
+  end
+
+  def schema(source)
+    Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      ReActionView::Template::Handlers::Herb.compile_for_schema(source, VIEW)
+    end
+  end
+
+  def page_visitor(source)
+    template = ActionView::Template.new(
+      source,
+      VIEW,
+      ReActionView::Template::Handlers::Herb,
+      virtual_path: "users/show",
+      format: :html,
+      locals: []
+    )
+
+    visitor = nil
+
+    Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      handler = ReActionView::Template::Handlers::Herb.new
+      visitor = handler.send(:slot_visitors, template, source).first
+      ReActionView.config.slot_mode_for(source)
+      base = handler.send(:base_visitors, template)
+
+      ReActionView::Template::Handlers::Herb.erb_implementation.new(
+        source,
+        filename: VIEW,
+        project_path: RAILS_ROOT,
+        visitors: [*base, visitor]
+      ).src
+    end
+
+    visitor
+  end
+
+  it "agrees with the page compile about the version" do
+    source = "<p><%= @name %></p><% if @open %><b>hi</b><% end %>"
+
+    assert_equal page_visitor(source).version, schema(source).version
+  end
+
+  it "answers the mode the template compiles in" do
+    assert_equal :client, schema("<p><%= @name %></p>").mode
+    assert_equal :server, schema("<%# herb:slots server %>\n<p><%= @name %></p>").mode
+  end
+
+  it "parks statics only in client mode" do
+    source = "<% if @open %><b>yes</b><% else %><i>no</i><% end %>"
+
+    refute_nil schema(source).statics
+
+    ReActionView.config.slots = :server
+
+    server_statics = schema(source).statics
+
+    assert server_statics.nil? || server_statics.empty?
+  end
+
+  it "carries the static markup" do
+    result = schema("<p>Hello, <%= @name %></p>")
+
+    assert_equal "<p>Hello, <!--herb-slot:0--><!--/herb-slot:0--></p>", result.static_markup
+  end
+
+  it "collects slot diagnostics" do
+    source = "<%# herb:state (count: 0) %>\n<% count = 5 %>\n<p><%= count %></p>\n"
+    result = schema(source)
+
+    assert_equal(["herb-state-assignment"], result.diagnostics.map { |diagnostic| diagnostic.code.to_s })
+  end
+
+  it "still compiles for diagnostics when slots are off" do
+    ReActionView.config.slots = false
+
+    result = schema("<p><%= @name %></p>")
+
+    assert_nil result.mode
+    assert_nil result.version
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,46 +180,46 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@4e8fd5a":
+"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@7598e6d":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@4e8fd5a#bebe7646495dbb2d2ebb7e668aa55592553a46e0"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@7598e6d#c97ca1db5fb00170778c4ec14dfecd4bc914a8eb"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@4e8fd5a"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@4e8fd5a":
+"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@7598e6d":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@4e8fd5a#58bfe8b688dd0b9cd52802ce1cc0caec3238a249"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@7598e6d#af284fbddcf2cca2d9edd839a18e8264fd545939"
 
-"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@4e8fd5a":
+"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d":
   version "0.10.3"
-  uid "7e83bd39d13bb4c48600bb43f8c32afe5a811ee8"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@4e8fd5a#7e83bd39d13bb4c48600bb43f8c32afe5a811ee8"
+  uid "1b61a62ae98888ac7d9871fc4857d71d91aba82b"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d#1b61a62ae98888ac7d9871fc4857d71d91aba82b"
   dependencies:
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@main":
+"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@7598e6d":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@main#7b8735b44a7421281edf00a49b6413a3af70392e"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@7598e6d#dfe6ac1b2a21230f5feb195fd59fe689a86a2427"
   dependencies:
-    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@4e8fd5a"
-    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@4e8fd5a"
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@4e8fd5a"
-    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@4e8fd5a"
+    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@7598e6d"
+    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@7598e6d"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
+    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@7598e6d"
 
-"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@4e8fd5a":
+"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@7598e6d":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@4e8fd5a#216a1b355ce10848990446c36c2bf25d95f79f51"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@7598e6d#86fc9691fcd94c7811dfe2ec293305770cdbb952"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@4e8fd5a"
-    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@4e8fd5a"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
+    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@7598e6d"
     ansi_up "^6.0.6"
 
-"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@4e8fd5a":
+"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@7598e6d":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@4e8fd5a#c7934f89f6dca81f044086ce7d44a3de35e85363"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@7598e6d#ba16742edfa8c67af4ec3804f5d20b21dae702b5"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@4e8fd5a"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
     "@ruby/prism" "^1.9.0"
 
 "@iconify-json/logos@^1.2.4":


### PR DESCRIPTION
This pull request wires ReActionView into the Herb dev server, so editing a template in development resolves in the browser at the cheapest tier the page can afford instead of reloading it. The server half of the protocol is marcoroth/herb#2515 and the browser half is marcoroth/herb#2516.

Exactly one process can compile templates, the application, because slot identity depends on the full visitor stack a host assembles per template. The railtie registers that compiler and boots the dev server inside the Rails server process:

```ruby
::Herb::Dev.compiler = ReActionView::Slots::DevCompiler.new

app.server { Railtie.boot_dev_server }
```

`DevCompiler` compiles the way the application would, through the new `Herb.compile_for_schema` on the template handler, with the same validation, debug, head and transform visitors a real render uses, wrapped in the Rails executor since the watcher calls it from its own thread. The handler's visitor assembly is extracted into `base_visitors` so the render path, the dependencies path and the schema path stop drifting apart.

The dev server starts whenever slots are on in development. A new `config.dev_server = false` turns it off, and the boot logs through `Rails.logger` under a `[Herb Dev Server]` prefix with a one-line banner next to Puma's.

Two rendering changes close the loop for the browser:

- A request carrying the `Herb-Schema` header gets the compiled schema merged into the slots JSON response. The dev tools use this as the pull fallback when a page loads before the socket has pushed anything.
- A raise during a slots re-render in development answers with a 500 and a structured error, so the dev tools can hold the page and put the actual Ruby error on the diagnostics panel instead of reloading into an error screen.

```json
{ "error": { "class": "NoMethodError", "message": "undefined method 'sent_label'", "template": "chat/show" } }
```
