### PR TITLE
Send the backtrace when a slots re-render raises

### DIFF
--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@7598e6d"
+    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d66dbac"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/lib/reactionview/slots/rendering.rb
+++ b/lib/reactionview/slots/rendering.rb
@@ -43,9 +43,17 @@ module ReActionView
           class: cause.class.name,
           message: cause.message,
           template: template.respond_to?(:short_identifier) ? template.short_identifier : nil,
+          backtrace: cleaned_backtrace(cause),
         }
 
         ::JSON.generate({ error: entry })
+      end
+
+      def cleaned_backtrace(cause)
+        raw = cause.backtrace || []
+        cleaned = ::Rails.backtrace_cleaner.clean(raw)
+
+        (cleaned.empty? ? raw : cleaned).first(5)
       end
 
       def merge_schema(rendered, options)

--- a/test/slots/rendering_test.rb
+++ b/test/slots/rendering_test.rb
@@ -36,6 +36,21 @@ class ReActionView::Slots::RenderingTest < Minitest::Spec
     end
   end
 
+  class Raising
+    prepend ReActionView::Slots::Rendering
+
+    attr_accessor :status
+    attr_reader :request
+
+    def initialize
+      @request = Request.new(Format.new(ReActionView::Slots::FORMAT))
+    end
+
+    def render_to_body(_options = {})
+      raise ::NoMethodError, "undefined method 'sent_label'"
+    end
+  end
+
   class Controller
     def render_to_body(options = {})
       options[:body]
@@ -198,6 +213,32 @@ class ReActionView::Slots::RenderingTest < Minitest::Spec
 
     test "leaves a values response alone" do
       assert_equal "{\"a\":1}", page_body(ReActionView::Slots::FORMAT, { a: 1 })
+    end
+  end
+
+  describe "a raise during a slots re-render" do
+    test "answers with a structured error and the first backtrace frames" do
+      controller = Raising.new
+
+      body = ReActionView.config.stub(:development?, true) do
+        ::JSON.parse(controller.render_to_body)
+      end
+
+      assert_equal 500, controller.status
+      assert_equal "NoMethodError", body["error"]["class"]
+      assert_equal "undefined method 'sent_label'", body["error"]["message"]
+      assert_operator body["error"]["backtrace"].length, :<=, 5
+      assert_includes body["error"]["backtrace"].first, "rendering_test.rb"
+    end
+
+    test "keeps raising outside development" do
+      controller = Raising.new
+
+      assert_raises(::NoMethodError) do
+        ReActionView.config.stub(:development?, false) do
+          controller.render_to_body
+        end
+      end
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,46 +180,46 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@7598e6d":
+"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d66dbac":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@7598e6d#c97ca1db5fb00170778c4ec14dfecd4bc914a8eb"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d66dbac#3158719b1e13588548acae6f19580a774434e2ab"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@7598e6d":
+"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d66dbac":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@7598e6d#af284fbddcf2cca2d9edd839a18e8264fd545939"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d66dbac#62a6aea428e969c1d8a15ff0008a7a0ccb45ad88"
 
-"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d":
+"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac":
   version "0.10.3"
-  uid "1b61a62ae98888ac7d9871fc4857d71d91aba82b"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d#1b61a62ae98888ac7d9871fc4857d71d91aba82b"
+  uid "6fce71cfecf506c11fe9f498e3893ab6d0276f35"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac#6fce71cfecf506c11fe9f498e3893ab6d0276f35"
   dependencies:
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@7598e6d":
+"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d66dbac":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@7598e6d#dfe6ac1b2a21230f5feb195fd59fe689a86a2427"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d66dbac#633dd909c6af17c921e52306ddae91924177ebf8"
   dependencies:
-    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@7598e6d"
-    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@7598e6d"
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
-    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@7598e6d"
+    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d66dbac"
+    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d66dbac"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
+    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d66dbac"
 
-"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@7598e6d":
+"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d66dbac":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@7598e6d#86fc9691fcd94c7811dfe2ec293305770cdbb952"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d66dbac#d20083d669acf3acc1a3952eb965beaf59bc3216"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
-    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@7598e6d"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
+    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d66dbac"
     ansi_up "^6.0.6"
 
-"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@7598e6d":
+"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d66dbac":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@7598e6d#ba16742edfa8c67af4ec3804f5d20b21dae702b5"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d66dbac#42aec8665a2c7a6b022ec49a6a618bbf167f9247"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@7598e6d"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
     "@ruby/prism" "^1.9.0"
 
 "@iconify-json/logos@^1.2.4":


### PR DESCRIPTION
The structured error a raising re-render answers with now carries the first five frames of the backtrace, cleaned through `Rails.backtrace_cleaner` so they come out app-relative, with the raw frames as the fallback when the cleaner strips everything. The Herb dev tools render them on the diagnostics card as a frame list below the render stack, with `path:line` frames linking into the editor, from marcoroth/herb#2522.

```json
{ "error": { "class": "NoMethodError", "message": "undefined method 'sent_label'", "template": "chat/show", "backtrace": ["app/models/message.rb:12:in 'sent_label'"] } }
```