### PR TITLE
Add built-in Herb instrumentations to measure what a page did

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 52eebc7bb24eec742870daea9891028a49a6e29f
   branch: main
   specs:
     herb (0.10.3)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ ReActionView.configure do |config|
 
   # How to handle templates that come from gems (:fallback, :skip, or :compile), defaults to :fallback
   # config.external_template_mode = :skip
+
+  # Measure what a page does while it renders, defaults to on in development
+  # config.instrumentation.enabled = Rails.env.development?
+
+  # Each measurement can be turned off on its own
+  # config.instrumentation.sql_queries = false
+  # config.instrumentation.render_times = false
+  # config.instrumentation.translations = false
 end
 ```
 

--- a/docs/.vitepress/config/theme.mts
+++ b/docs/.vitepress/config/theme.mts
@@ -14,6 +14,7 @@ const defaultSidebar = [
       { text: "Debug Mode", link: "/guides/debug-mode" },
       { text: "Validation Overlays", link: "/guides/validation-overlays" },
       { text: "Development Tools", link: "/guides/development-tools" },
+      { text: "Runtime Instrumentation", link: "/guides/runtime-instrumentation" },
     ],
   },
   {

--- a/docs/docs/guides/runtime-instrumentation.md
+++ b/docs/docs/guides/runtime-instrumentation.md
@@ -1,0 +1,71 @@
+# Runtime Instrumentation
+
+ReActionView can measure what a page did while it rendered, and file each measurement against the ERB tag that caused it. A `render` call that ran fifteen queries says so on the line it was written on, rather than in a log you have to correlate by hand.
+
+## Configuration
+
+Measuring follows development unless you say otherwise:
+
+:::code-group
+```ruby [config/initializers/reactionview.rb]
+ReActionView.configure do |config|
+  config.instrumentation.enabled = Rails.env.development?
+end
+```
+:::
+
+Measuring means instrumenting every ERB tag, which is worth it while you are working on a page and not while anyone else is reading one. Turning it off leaves your templates compiling exactly as they would without ReActionView's instrumentation.
+
+## What it measures
+
+Three measurements are built in, and each can be turned off on its own:
+
+| Option | What it records | Reads as |
+|---|---|---|
+| `sql_queries` | The statements a tag ran, minus cached, schema and transaction queries | `5 SQL queries` |
+| `render_times` | What a render cost, with its GC time and allocations | `1.4 ms` |
+| `translations` | What a `t(...)` or `translate(...)` tag rendered | `Hello World` |
+
+:::code-group
+```ruby [config/initializers/reactionview.rb]
+ReActionView.configure do |config|
+  config.instrumentation.render_times = false
+end
+```
+:::
+
+The options are seeded with the keys they expect and refuse the ones they do not, so a mistyped option is an `ArgumentError` at boot instead of a measurement that quietly keeps running:
+
+```ruby
+config.instrumentation.render_time = false
+# => ArgumentError: unknown instrumentation option :render_time, expected one of
+#    [:enabled, :sql_queries, :render_times, :translations]
+```
+
+## Where the numbers come from
+
+Rails already announces this work through `ActiveSupport::Notifications`, so nothing is measured twice. A render reports the duration, GC time and allocation count that Rails put on the event, and a query is skipped when it was served from cache, because that is not a query the page paid for.
+
+Herb's instrumentation supplies the other half: it says which tag is rendering at any moment, so whatever a subscriber observes is filed against the tag that was open at the time.
+
+## Where they show up
+
+Measurements appear in the Herb dev tools panel in the browser, beside the diagnostics for the same page. Each one shows what was observed behind its count, so `5 SQL queries` opens to the statements themselves.
+
+They are also written to a journal on disk, keyed by the template and a digest of its contents, which is what lets the Herb Language Server show them in your editor on the line they belong to. A template that has been edited since it was rendered shows nothing rather than something misleading.
+
+## Measuring something of your own
+
+The built-ins are ordinary subscribers and measurements. Anything your application knows how to observe can be recorded the same way:
+
+```ruby
+ActiveSupport::Notifications.subscribe("cache_read.active_support") do |*, payload|
+  Herb::Engine::Runtime::Session.observe(:cache, payload[:key])
+end
+
+Herb::Engine::Runtime::Session.measurement(:cache, origin: "My App", code: "cache-reads") do |keys|
+  "#{keys.size} cache #{"read".pluralize(keys.size)}"
+end
+```
+
+The block is given everything observed for one tag and returns the line the tools show. Anything else it recorded stays available underneath it.

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d66dbac"
+    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d2d24cf"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/lib/generators/reactionview/install_generator.rb
+++ b/lib/generators/reactionview/install_generator.rb
@@ -32,6 +32,13 @@ module ReActionView
             # How to handle templates that come from gems (:fallback, :skip, or :compile), defaults to :fallback
             # config.external_template_mode = :skip
 
+            # Measure what a page does while it renders, and show it in the dev tools.
+            # Follows development unless you say otherwise, and each measurement can be turned off.
+            # config.instrumentation.enabled = Rails.env.development?
+            # config.instrumentation.sql_queries = false
+            # config.instrumentation.render_times = false
+            # config.instrumentation.translations = false
+
             # Add custom transform visitors to process templates before compilation
             # config.transform_visitors = [
             #   Herb::Visitor::new

--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -25,6 +25,7 @@ module ReActionView
       @transform_visitors = []
       @project_path = nil
       @slots = false
+      @instrumentation = nil
     end
 
     def dev_server_enabled?
@@ -89,6 +90,31 @@ module ReActionView
       return @debug_mode unless @debug_mode.nil?
 
       development?
+    end
+
+    def instrumentation
+      @instrumentation ||= InstrumentationOptions.new(enabled: development?)
+    end
+
+    class InstrumentationOptions < ::ActiveSupport::OrderedOptions
+      BUILT_INS = [:sql_queries, :render_times, :translations].freeze
+      KEYS = ([:enabled] + BUILT_INS).freeze
+
+      def initialize(enabled:)
+        super()
+
+        merge!(enabled: enabled, **BUILT_INS.to_h { |key| [key, true] })
+      end
+
+      def []=(key, value)
+        raise ArgumentError, "unknown instrumentation option #{key.inspect}, expected one of #{KEYS.inspect}" unless KEYS.include?(key.to_sym)
+
+        super
+      end
+
+      def measuring?(built_in)
+        !!self[:enabled] && !!self[built_in]
+      end
     end
 
     def dev_server_port

--- a/lib/reactionview/instrumentation.rb
+++ b/lib/reactionview/instrumentation.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+module ReActionView
+  # What a page did while it rendered, filed against the tags that did it.
+  #
+  # `Herb::Engine::InstrumentationVisitor` says which tag is rendering at any moment. It does not
+  # say what is worth noticing while one is, because that is not the engine's business: an
+  # application knows what it cares about, and Rails already announces most of it through
+  # `ActiveSupport::Notifications`.
+  #
+  # These are the three worth having in every application, so they are here rather than in each one:
+  # the queries a tag ran, what a render cost, and what a translation rendered. Each is a subscriber
+  # that observes, plus a measurement that says how to read what was observed. Either half can be
+  # turned off on its own.
+  #
+  #     ReActionView.configure do |config|
+  #       config.instrumentation = true
+  #       config.instrumentation.sql_queries = false
+  #     end
+  #
+  module Instrumentation
+    TRANSLATION_TAGS = [/\At\(/, /\Atranslate\(/].freeze #: Array[Regexp]
+    IGNORED_QUERIES = ["SCHEMA", "TRANSACTION"].freeze #: Array[String]
+    RENDER_EVENTS = %w[
+      render_partial.action_view
+      render_collection.action_view
+      render_template.action_view
+    ].freeze #: Array[String]
+
+    def self.available?
+      require "herb/engine/runtime/session"
+
+      ::Herb::Engine::Runtime::Session.respond_to?(:measurement)
+    rescue LoadError
+      false
+    end
+
+    def self.install!(config = ReActionView.config)
+      return unless config.instrumentation.enabled
+      return unless available?
+      return if installed?
+
+      @installed = true
+
+      install_sql_queries if config.instrumentation.measuring?(:sql_queries)
+      install_render_times if config.instrumentation.measuring?(:render_times)
+      install_translations if config.instrumentation.measuring?(:translations)
+
+      config.transform_visitors += [visitor(config)]
+
+      nil
+    end
+
+    def self.installed?
+      @installed == true
+    end
+
+    def self.reset!
+      @installed = false
+    end
+
+    def self.visitor(config = ReActionView.config)
+      require "herb/engine/visitors/instrumentation_visitor"
+
+      ::Herb::Engine::InstrumentationVisitor.new(capture_output: config.instrumentation.measuring?(:translations) ? TRANSLATION_TAGS : nil)
+    end
+
+    def self.install_sql_queries
+      ::ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        next if payload[:cached]
+        next if IGNORED_QUERIES.include?(payload[:name])
+
+        session.observe(:queries, payload[:sql])
+      end
+
+      session.measurement(
+        :queries,
+        origin: "Herb Engine (Runtime)",
+        code: "sql-queries",
+        description: ->(queries) { "This ERB tag ran #{queries.size} SQL #{"query".pluralize(queries.size)} while the page rendered." }
+      ) { |queries| "#{queries.size} SQL #{"query".pluralize(queries.size)}" }
+    end
+
+    def self.install_render_times
+      RENDER_EVENTS.each do |event|
+        ::ActiveSupport::Notifications.subscribe(event) do |notification|
+          session.observe(:render, {
+            duration: notification.duration.round(2),
+            gc: notification.gc_time.round(2),
+            allocations: notification.allocations,
+            cached: notification.payload[:cache_hit] ? true : nil,
+          }.compact)
+        end
+      end
+
+      session.measurement(:render, origin: "Herb Engine (Runtime)", code: "render-time", description: method(:render_description)) do |renders|
+        duration = renders.sum { |render| render[:duration] }.round(1)
+
+        renders.size > 1 ? "#{duration} ms over #{renders.size} renders" : "#{duration} ms"
+      end
+    end
+
+    def self.install_translations
+      session.measurement(
+        :output,
+        origin: "Herb Engine (Runtime)",
+        code: "rendered-output",
+        kind: :value,
+        per: :position,
+        description: ->(values) { "This ERB tag rendered #{values.last.to_s.strip.inspect} when the page was last built." }
+      ) { |values| values.last.to_s }
+    end
+
+    def self.render_description(renders)
+      duration = renders.sum { |render| render[:duration] }
+      gc = renders.sum { |render| render[:gc] }
+      allocations = renders.sum { |render| render[:allocations] }
+      cached = renders.count { |render| render[:cached] }
+
+      parts = ["taking #{duration.round(1)} ms"]
+      parts << "#{gc.round(1)} ms of it in GC" if gc.positive?
+      parts << "allocating #{allocations.to_fs(:delimited)} objects" if allocations.positive?
+      parts << "#{cached} served from cache" if cached.positive?
+
+      if renders.size > 1
+        "This tag rendered #{renders.size} times, #{parts.to_sentence}. Slowest was #{renders.map { |render| render[:duration] }.max.round(1)} ms."
+      else
+        "This tag rendered once, #{parts.to_sentence}."
+      end
+    end
+
+    def self.session
+      ::Herb::Engine::Runtime::Session
+    end
+  end
+end

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -39,6 +39,14 @@ module ReActionView
       app.middleware.use ::Herb::Engine::Runtime::Middleware
     end
 
+    initializer "reactionview.instrumentation", after: :load_config_initializers do |_app|
+      next unless ReActionView.config.instrumentation.enabled
+
+      require_relative "instrumentation"
+
+      ReActionView::Instrumentation.install!
+    end
+
     initializer "reactionview.error_page", after: :load_config_initializers do |app|
       next unless ReActionView.config.development?
 

--- a/test/reactionview/instrumentation_test.rb
+++ b/test/reactionview/instrumentation_test.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "reactionview/instrumentation"
+
+class ReActionView::InstrumentationTest < Minitest::Spec
+  def development_config
+    config = ReActionView::Config.new
+
+    def config.development?
+      true
+    end
+
+    config
+  end
+
+  before do
+    skip "this Herb has no measurement API" unless ReActionView::Instrumentation.available?
+  end
+
+  after do
+    ReActionView::Instrumentation.reset!
+    ::Herb::Engine::Runtime::Session.clear_measurements if ::Herb::Engine::Runtime::Session.respond_to?(:clear_measurements)
+  end
+
+  describe "when it runs" do
+    test "measures while you are working on a page, and not otherwise" do
+      config = ReActionView::Config.new
+
+      def config.development?
+        false
+      end
+
+      refute config.instrumentation.enabled
+      assert development_config.instrumentation.enabled
+    end
+
+    test "measures anywhere it is asked for by name" do
+      config = ReActionView::Config.new
+
+      def config.development?
+        false
+      end
+
+      config.instrumentation.enabled = true
+
+      assert config.instrumentation.enabled
+    end
+
+    test "installs nothing when nothing is being measured" do
+      config = ReActionView::Config.new
+      config.instrumentation.enabled = false
+
+      ReActionView::Instrumentation.install!(config)
+
+      refute_predicate ReActionView::Instrumentation, :installed?
+      assert_empty ::Herb::Engine::Runtime::Session.measurements
+      assert_empty config.transform_visitors
+    end
+
+    test "installs once, however often it is asked" do
+      config = development_config
+
+      ReActionView::Instrumentation.install!(config)
+      ReActionView::Instrumentation.install!(config)
+
+      assert_equal 3, ::Herb::Engine::Runtime::Session.measurements.size
+      assert_equal 1, config.transform_visitors.size
+    end
+
+    test "hands the compiler the visitor that makes a template say what it is rendering" do
+      config = development_config
+
+      ReActionView::Instrumentation.install!(config)
+
+      assert_kind_of ::Herb::Engine::InstrumentationVisitor, config.transform_visitors.first
+    end
+  end
+
+  describe "an engine that cannot be measured" do
+    test "installs nothing rather than failing to boot" do
+      ReActionView::Instrumentation.stub(:available?, false) do
+        ReActionView::Instrumentation.install!(development_config)
+      end
+
+      refute_predicate ReActionView::Instrumentation, :installed?
+    end
+  end
+
+  describe "how it is configured" do
+    test "turns the whole thing off in one word" do
+      config = development_config
+      config.instrumentation.enabled = false
+
+      refute config.instrumentation.enabled
+      refute config.instrumentation.measuring?(:sql_queries)
+    end
+
+    test "remembers the built-ins that were turned off while it was off" do
+      config = development_config
+      config.instrumentation.render_times = false
+      config.instrumentation.enabled = false
+      config.instrumentation.enabled = true
+
+      assert config.instrumentation.measuring?(:sql_queries)
+      refute config.instrumentation.measuring?(:render_times)
+    end
+  end
+
+  describe "which measurements it installs" do
+    test "installs all three by default" do
+      ReActionView::Instrumentation.install!(development_config)
+
+      assert_equal %w[sql-queries render-time rendered-output], ::Herb::Engine::Runtime::Session.measurements.map(&:code)
+    end
+
+    test "leaves out the one that was turned off" do
+      config = development_config
+      config.instrumentation.sql_queries = false
+
+      ReActionView::Instrumentation.install!(config)
+
+      assert_equal %w[render-time rendered-output], ::Herb::Engine::Runtime::Session.measurements.map(&:code)
+    end
+
+    test "turns each of them off on its own" do
+      config = development_config
+      config.instrumentation.render_times = false
+      config.instrumentation.translations = false
+
+      ReActionView::Instrumentation.install!(config)
+
+      assert_equal %w[sql-queries], ::Herb::Engine::Runtime::Session.measurements.map(&:code)
+    end
+
+    test "keeps them all off while nothing is being measured" do
+      config = ReActionView::Config.new
+      config.instrumentation.enabled = false
+      config.instrumentation.sql_queries = true
+
+      refute config.instrumentation.measuring?(:sql_queries)
+    end
+
+    test "comes with every key it expects, and refuses the ones it does not" do
+      options = ReActionView::Config.new.instrumentation
+
+      assert_equal ReActionView::Config::InstrumentationOptions::KEYS.sort, options.keys.sort
+
+      error = assert_raises(ArgumentError) { options.sql_querys = false }
+
+      assert_includes error.message, "unknown instrumentation option"
+    end
+  end
+
+  describe "the visitor it hands to the compiler" do
+    test "knows a translation tag by either name it is written under" do
+      matchers = ReActionView::Instrumentation::TRANSLATION_TAGS
+
+      assert(matchers.any? { |matcher| matcher.match?('t(".title")') })
+      assert(matchers.any? { |matcher| matcher.match?('translate(".title")') })
+      refute(matchers.any? { |matcher| matcher.match?("title") })
+    end
+
+    test "captures nothing once translations are turned off" do
+      config = development_config
+      config.instrumentation.translations = false
+
+      source = "<%= t(\".title\") %>"
+      compiled = ::Herb::Engine.new(source, filename: "a.html.erb", visitors: [ReActionView::Instrumentation.visitor(config)]).src
+
+      refute_includes compiled, "Session.output"
+    end
+
+    test "captures a translation while they are on" do
+      source = "<%= t(\".title\") %>"
+      compiled = ::Herb::Engine.new(source, filename: "a.html.erb", visitors: [ReActionView::Instrumentation.visitor(development_config)]).src
+
+      assert_includes compiled, "Session.output"
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,46 +180,46 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d66dbac":
+"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d2d24cf":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d66dbac#3158719b1e13588548acae6f19580a774434e2ab"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d2d24cf#d9d168d7f646f605ebdda86449a05718c28e5f1e"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d66dbac":
+"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d2d24cf":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d66dbac#62a6aea428e969c1d8a15ff0008a7a0ccb45ad88"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d2d24cf#62a6aea428e969c1d8a15ff0008a7a0ccb45ad88"
 
-"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac":
+"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf":
   version "0.10.3"
-  uid "6fce71cfecf506c11fe9f498e3893ab6d0276f35"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac#6fce71cfecf506c11fe9f498e3893ab6d0276f35"
+  uid "42c1f99c434a405786199807507a06cab628c8ed"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf#42c1f99c434a405786199807507a06cab628c8ed"
   dependencies:
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d66dbac":
+"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d2d24cf":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d66dbac#633dd909c6af17c921e52306ddae91924177ebf8"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d2d24cf#f7c1d8aa5c5d13020a6a0476e27430c788e7e457"
   dependencies:
-    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d66dbac"
-    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d66dbac"
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
-    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d66dbac"
+    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d2d24cf"
+    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d2d24cf"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
+    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d2d24cf"
 
-"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d66dbac":
+"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d2d24cf":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d66dbac#d20083d669acf3acc1a3952eb965beaf59bc3216"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d2d24cf#7bd03ffb274dc710825b08fe91e86155c819f500"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
-    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d66dbac"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
+    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d2d24cf"
     ansi_up "^6.0.6"
 
-"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d66dbac":
+"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d2d24cf":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d66dbac#42aec8665a2c7a6b022ec49a6a618bbf167f9247"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d2d24cf#c68186cdb9e4b955d1319da6780e4fccbcb07e30"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d66dbac"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
     "@ruby/prism" "^1.9.0"
 
 "@iconify-json/logos@^1.2.4":


### PR DESCRIPTION
This pull request adds 3 built-in measurements to ReActionView, so an application gets them by configuring one thing instead of writing the subscribers by hand.

Herb's instrumentation says which tag is rendering at any moment. It deliberately does not say what is worth noticing while one is, because that is not the engine's business, and Rails already announces most of it through `ActiveSupport::Notifications`. 

The result was that every application ended up writing the same three subscribers, each with the same measurement beside it: the queries a tag ran, what a render cost, and what a translation rendered.

```ruby
ReActionView.configure do |config|
  config.instrumentation.enabled = true
  config.instrumentation.render_times = false
end
```