### PR TITLE
Steer a values re-render with the client's Herb-State header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,9 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/BlockLength:
   Max: 30
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 52eebc7bb24eec742870daea9891028a49a6e29f
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: bc6d8e39a638453d9615c4a709fe552dc09af5b9
+  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
   branch: main
   specs:
     herb (0.10.3)

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d2d24cf"
+    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@1da6e95"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@1da6e95"
+    "@herb-tools/dev-tools": "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@1da6e9566"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/lib/reactionview.rb
+++ b/lib/reactionview.rb
@@ -20,6 +20,7 @@ require_relative "reactionview/config"
 require_relative "reactionview/slots"
 require_relative "reactionview/slots/resolver"
 require_relative "reactionview/slots/rendering"
+require_relative "reactionview/slots/state_overrides"
 require_relative "reactionview/slots/dev_compiler"
 
 require_relative "reactionview/template/local_template"

--- a/lib/reactionview/instrumentation.rb
+++ b/lib/reactionview/instrumentation.rb
@@ -56,7 +56,14 @@ module ReActionView
     end
 
     def self.reset!
+      subscriptions.each { |subscription| ::ActiveSupport::Notifications.unsubscribe(subscription) }
+      subscriptions.clear
+
       @installed = false
+    end
+
+    def self.subscriptions
+      @subscriptions ||= []
     end
 
     def self.visitor(config = ReActionView.config)
@@ -66,7 +73,7 @@ module ReActionView
     end
 
     def self.install_sql_queries
-      ::ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      subscriptions << ::ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
         next if payload[:cached]
         next if IGNORED_QUERIES.include?(payload[:name])
 
@@ -83,11 +90,11 @@ module ReActionView
 
     def self.install_render_times
       RENDER_EVENTS.each do |event|
-        ::ActiveSupport::Notifications.subscribe(event) do |notification|
+        subscriptions << ::ActiveSupport::Notifications.subscribe(event) do |notification|
           session.observe(:render, {
             duration: notification.duration.round(2),
-            gc: notification.gc_time.round(2),
-            allocations: notification.allocations,
+            gc: notification.respond_to?(:gc_time) ? notification.gc_time.round(2) : 0.0,
+            allocations: notification.respond_to?(:allocations) ? notification.allocations : 0,
             cached: notification.payload[:cache_hit] ? true : nil,
           }.compact)
         end

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -68,7 +68,12 @@ module ReActionView
 
       Mime::Type.register ReActionView::Slots::MIME_TYPE, ReActionView::Slots::FORMAT unless Mime[ReActionView::Slots::FORMAT]
 
+      ActiveSupport.on_load(:action_view) do
+        include ReActionView::Slots::StateOverridesHelper
+      end
+
       ActiveSupport.on_load(:action_controller_base) do
+        include ReActionView::Slots::StateOverridesHelper
         prepend ReActionView::Slots::Rendering
 
         app.config.paths["app/views"].existent.each do |path|

--- a/lib/reactionview/slots.rb
+++ b/lib/reactionview/slots.rb
@@ -22,5 +22,17 @@ module ReActionView
     def self.reset_dependencies!
       @dependencies = nil
     end
+
+    #: (String, Integer) -> String?
+    def self.block_program(path, index)
+      mtime = ::File.mtime(path)
+      key = [path, index, mtime]
+
+      (@block_programs_lock ||= ::Mutex.new).synchronize do
+        programs = (@block_programs ||= {})
+        programs.clear if programs.size > 128 && !programs.key?(key)
+        programs[key] ||= ReActionView::Template::Handlers::Herb.compile_for_block(::File.read(path), path, index)
+      end
+    end
   end
 end

--- a/lib/reactionview/slots/rendering.rb
+++ b/lib/reactionview/slots/rendering.rb
@@ -6,6 +6,7 @@ module ReActionView
   module Slots
     module Rendering
       BODY_END_TAG = "</body>"
+      BLOCK_HEADER = "Herb-Block"
 
       def _normalize_options(options)
         super
@@ -16,6 +17,18 @@ module ReActionView
       end
 
       def render_to_body(options = {})
+        protect_steered_response
+
+        if (block = scoped_block_index)
+          begin
+            return ::JSON.generate(render_scoped_block(block, options))
+          rescue ::StandardError => e
+            raise unless ReActionView.config.development?
+
+            return render_slots_error(e)
+          end
+        end
+
         begin
           rendered = super
         rescue ::StandardError => e
@@ -32,6 +45,14 @@ module ReActionView
       end
 
       private
+
+      def protect_steered_response
+        return unless slots_request?
+        return unless request.respond_to?(:headers) && respond_to?(:response) && response
+        return if request.headers[StateOverrides::HEADER].nil?
+
+        response.headers["Cache-Control"] = "no-store"
+      end
 
       def render_slots_error(error)
         self.status = 500
@@ -77,6 +98,26 @@ module ReActionView
         logger&.debug { "ReActionView could not build the schema envelope: #{e.class}: #{e.message}" }
 
         rendered
+      end
+
+      def scoped_block_index
+        return nil unless slots_request?
+
+        value = request.headers[BLOCK_HEADER]
+
+        value&.match?(/\A\d+\z/) ? Integer(value, 10) : nil
+      end
+
+      def render_scoped_block(index, options)
+        entry = entry_point_for(options)
+
+        raise ::ArgumentError, "a scoped block request found no entry template" unless entry
+
+        program = ReActionView::Slots.block_program(entry, index)
+
+        raise ::ArgumentError, "the entry template compiles no slots, so it holds no block \#{index}" unless program
+
+        view_context.instance_eval(program, entry)
       end
 
       def slots_request?

--- a/lib/reactionview/slots/state_overrides.rb
+++ b/lib/reactionview/slots/state_overrides.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "json"
+
+module ReActionView
+  module Slots
+    # Parses the `Herb-State` request header a client sends with a values request.
+    #
+    # The header carries the client's state so the compiled values program evaluates
+    # the branches the client is showing. The parse is lenient on purpose, since a
+    # malformed or oversized header must degrade to the compiled defaults and never
+    # break a render.
+    #
+    module StateOverrides
+      HEADER = "Herb-State" #: String
+      MAX_BYTES = 8192 #: Integer
+
+      #: (String?) -> Hash[String, Hash[String, untyped]]?
+      def self.parse(header_value)
+        return nil if header_value.nil? || header_value.strip.empty?
+        return nil if header_value.bytesize > MAX_BYTES
+
+        raw = ::JSON.parse(header_value)
+
+        return nil unless raw.is_a?(::Hash)
+
+        overrides = raw.select { |key, value| key.is_a?(::String) && value.is_a?(::Hash) }
+
+        overrides.empty? ? nil : overrides
+      rescue ::JSON::ParserError
+        nil
+      end
+    end
+
+    module StateOverridesHelper
+      #: () -> Hash[String, Hash[String, untyped]]?
+      def __herb_state_overrides
+        return @__herb_state_overrides if defined?(@__herb_state_overrides)
+
+        header = respond_to?(:request) && request ? request.headers[StateOverrides::HEADER] : nil
+
+        @__herb_state_overrides = StateOverrides.parse(header)
+      end
+
+      #: (?String?, ?untyped) -> untyped
+      def herb_state(name = nil, default = nil)
+        overrides = __herb_state_overrides
+
+        return overrides if name.nil?
+        return default if overrides.nil?
+
+        overrides.each_value do |states|
+          return states[name] if states.key?(name)
+        end
+
+        default
+      end
+    end
+  end
+end

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -41,6 +41,10 @@ module ReActionView
           new.compile_for_schema(source, path)
         end
 
+        def self.compile_for_block(source, path, index)
+          new.compile_for_block(source, path, index)
+        end
+
         def call(template, source, validation_mode: nil)
           mode = validation_mode || ReActionView.config.validation_mode
 
@@ -73,6 +77,23 @@ module ReActionView
           ).src
 
           visitor
+        end
+
+        def compile_for_block(source, path, index)
+          template = ::Struct.new(:identifier, :format).new(path, :html)
+          visitor = slot_visitors(template, source, mark: false).first
+
+          return nil unless visitor
+
+          ::Herb::Engine::Slots::DynamicsCompiler.new(
+            source,
+            filename: translate_path_for_editor(path),
+            project_path: ::ReActionView.config.project_path,
+            visitors: base_visitors(template),
+            slot_visitor: visitor,
+            block: index,
+            **VALUES_ESCAPING
+          ).src
         end
 
         def compile_for_schema(source, path)

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -58,7 +58,9 @@ module ReActionView
 
           return values_source(template, source, config) if values_format?(template)
 
-          config[:visitors] = [*visitors, *slot_visitors(template, source)]
+          slots = slot_visitors(template, source)
+
+          config[:visitors] = slots.any? ? [*visitors, *slots] : [*visitors, *rewriting_transform_visitors]
 
           erb_implementation.new(source, config).src
         end
@@ -112,12 +114,28 @@ module ReActionView
         private
 
         def base_visitors(template, validation_mode: ReActionView.config.validation_mode)
+          passive, _rewriting = partitioned_transform_visitors
+
           [
             *validation_visitors(validation_mode),
             *debug_visitors(template),
             *head_visitors(template),
-            *ReActionView.config.transform_visitors
+            *passive
           ]
+        end
+
+        def rewriting_transform_visitors
+          _passive, rewriting = partitioned_transform_visitors
+
+          rewriting
+        end
+
+        def partitioned_transform_visitors
+          ::ReActionView.config.transform_visitors.partition { |visitor|
+            klass = visitor.class
+
+            !(klass.respond_to?(:rewrites_erb_source?) && klass.rewrites_erb_source?)
+          }
         end
 
         def schema_validation_mode

--- a/test/slots/rendering_test.rb
+++ b/test/slots/rendering_test.rb
@@ -62,7 +62,10 @@ class ReActionView::Slots::RenderingTest < Minitest::Spec
   end
 
   Format = Struct.new(:symbol)
-  Request = Struct.new(:format)
+
+  Request = Struct.new(:format) do
+    def headers = {}
+  end
 
   class Normalizing
     attr_reader :request

--- a/test/slots/state_overrides_test.rb
+++ b/test/slots/state_overrides_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "action_controller"
+
+class ReActionView::Slots::StateOverridesTest < Minitest::Spec
+  Overrides = ReActionView::Slots::StateOverrides
+
+  RAILS_ROOT = "/app"
+  VIEW = "/app/app/views/users/show.html.erb"
+  IDENTIFIER = "app/views/users/show.html.erb"
+
+  STATE_SOURCE = <<~ERB
+    <%# herb:state (open: true) %>
+    <% if open %><span><%= @yes %></span><% else %><em><%= @no %></em><% end %>
+  ERB
+
+  before do
+    @previous_slots = ReActionView.config.slots
+
+    ReActionView.config.debug_mode = false
+    ReActionView.config.slots = true
+
+    Mime::Type.register(ReActionView::Slots::MIME_TYPE, ReActionView::Slots::FORMAT) unless Mime[ReActionView::Slots::FORMAT]
+  end
+
+  after do
+    ReActionView.config.slots = @previous_slots
+  end
+
+  class View
+    attr_accessor :__herb_state_overrides
+
+    def initialize(**assigns)
+      assigns.each { |name, value| instance_variable_set(:"@#{name}", value) }
+    end
+  end
+
+  FakeRequest = Struct.new(:headers)
+
+  class Helped
+    include ReActionView::Slots::StateOverridesHelper
+
+    attr_reader :request
+
+    def initialize(request)
+      @request = request
+    end
+  end
+
+  class SteeredController
+    include ReActionView::Slots::StateOverridesHelper
+    prepend ReActionView::Slots::Rendering
+
+    attr_reader :request, :response
+
+    def initialize(headers)
+      @request = ActionDispatch::Request.new(headers.transform_keys { |key| "HTTP_#{key.upcase.tr("-", "_")}" })
+      @request.format = ReActionView::Slots::FORMAT
+      @response = ActionDispatch::Response.new
+    end
+
+    def render_to_body(_options = {})
+      "{}"
+    end
+  end
+
+  def compile(source, format:)
+    template = ActionView::Template.new(
+      source,
+      VIEW,
+      ReActionView::Template::Handlers::Herb,
+      virtual_path: "users/show",
+      format: format,
+      locals: []
+    )
+
+    Rails.stub(:root, Pathname.new(RAILS_ROOT)) do
+      ReActionView::Template::Handlers::Herb.call(template, source)
+    end
+  end
+
+  def values(view)
+    view.instance_eval(compile(STATE_SOURCE, format: :slots))
+  end
+
+  def steered(overrides, **assigns)
+    view = View.new(**assigns)
+    view.__herb_state_overrides = overrides
+
+    values(view)
+  end
+
+  describe "parsing the header" do
+    test "nothing for a blank header" do
+      assert_nil Overrides.parse(nil)
+      assert_nil Overrides.parse("")
+      assert_nil Overrides.parse("   ")
+    end
+
+    test "nothing for a header past the size cap" do
+      assert_nil Overrides.parse(%({"a":"#{"x" * 9000}"}))
+    end
+
+    test "nothing for junk" do
+      assert_nil Overrides.parse("{not json")
+      assert_nil Overrides.parse("[1,2]")
+      assert_nil Overrides.parse(%("just a string"))
+    end
+
+    test "keeps only template entries shaped like state maps" do
+      parsed = Overrides.parse(%({"a.html.erb":{"open":true},"b.html.erb":"junk"}))
+
+      assert_equal({ "a.html.erb" => { "open" => true } }, parsed)
+      assert_nil Overrides.parse(%({"a.html.erb":"junk"}))
+    end
+  end
+
+  describe "the view helper" do
+    test "reads and memoizes the header" do
+      helped = Helped.new(FakeRequest.new({ Overrides::HEADER => %({"a.html.erb":{"open":false}}) }))
+
+      assert_equal({ "a.html.erb" => { "open" => false } }, helped.__herb_state_overrides)
+      assert_same helped.__herb_state_overrides, helped.__herb_state_overrides
+    end
+
+    test "answers nothing without a header" do
+      assert_nil Helped.new(FakeRequest.new({})).__herb_state_overrides
+    end
+
+    test "answers nothing without a request" do
+      helped = Helped.new(nil)
+
+      assert_nil helped.__herb_state_overrides
+    end
+  end
+
+  describe "reading state in a controller" do
+    test "a state the client sent is one method call away" do
+      controller = SteeredController.new(Overrides::HEADER => %({"app/views/chat/show.html.erb":{"q":"hello","open":false}}))
+
+      assert_equal "hello", controller.herb_state("q")
+      assert_equal false, controller.herb_state("open")
+    end
+
+    test "the default answers when the client said nothing" do
+      controller = SteeredController.new(Overrides::HEADER => %({"app/views/chat/show.html.erb":{"q":"hello"}}))
+
+      assert_equal "", controller.herb_state("missing", "")
+      assert_equal "", SteeredController.new({}).herb_state("q", "")
+    end
+
+    test "no name hands over everything, keyed by template" do
+      controller = SteeredController.new(Overrides::HEADER => %({"a.html.erb":{"q":"x"}}))
+
+      assert_equal({ "a.html.erb" => { "q" => "x" } }, controller.herb_state)
+      assert_nil SteeredController.new({}).herb_state
+    end
+
+    test "the first template naming the state wins" do
+      controller = SteeredController.new(Overrides::HEADER => %({"a.html.erb":{"q":"first"},"b.html.erb":{"q":"second"}}))
+
+      assert_equal "first", controller.herb_state("q")
+    end
+  end
+
+  describe "steering the values program" do
+    test "the defaults pick the compiled branch" do
+      payload = values(View.new(yes: "shown", no: "hidden"))
+
+      assert_equal "shown", payload[:slots][0][:slots].values.first
+    end
+
+    test "the client's state picks its branch" do
+      payload = steered({ IDENTIFIER => { "open" => false } }, yes: "shown", no: "hidden")
+
+      assert_equal "hidden", payload[:slots][0][:slots].values.first
+    end
+
+    test "a wrongly typed value falls back to the default" do
+      payload = steered({ IDENTIFIER => { "open" => 7 } }, yes: "shown", no: "hidden")
+
+      assert_equal "shown", payload[:slots][0][:slots].values.first
+    end
+
+    test "another template's state says nothing about this one" do
+      payload = steered({ "app/views/other.html.erb" => { "open" => false } }, yes: "shown", no: "hidden")
+
+      assert_equal "shown", payload[:slots][0][:slots].values.first
+    end
+
+    test "the page render ignores overrides entirely" do
+      view = View.new(yes: "shown", no: "hidden")
+      view.__herb_state_overrides = { IDENTIFIER => { "open" => false } }
+      view.instance_variable_set(:@output_buffer, ActionView::OutputBuffer.new)
+
+      rendered = view.instance_eval(compile(STATE_SOURCE, format: :html)).to_s
+
+      assert_includes rendered, "shown"
+      refute_includes rendered, "hidden"
+    end
+  end
+
+  describe "cache hygiene" do
+    test "a steered response is never stored" do
+      controller = SteeredController.new(Overrides::HEADER => %({"a.html.erb":{"open":false}}))
+      controller.render_to_body
+
+      assert_equal "no-store", controller.response.headers["Cache-Control"]
+    end
+
+    test "an unsteered response keeps its caching" do
+      controller = SteeredController.new({})
+      controller.render_to_body
+
+      assert_nil controller.response.headers["Cache-Control"]
+    end
+  end
+end

--- a/test/slots/state_overrides_test.rb
+++ b/test/slots/state_overrides_test.rb
@@ -56,7 +56,9 @@ class ReActionView::Slots::StateOverridesTest < Minitest::Spec
     attr_reader :request, :response
 
     def initialize(headers)
-      @request = ActionDispatch::Request.new(headers.transform_keys { |key| "HTTP_#{key.upcase.tr("-", "_")}" })
+      env = Rack::MockRequest.env_for("/").merge(headers.transform_keys { |key| "HTTP_#{key.upcase.tr("-", "_")}" })
+
+      @request = ActionDispatch::Request.new(env)
       @request.format = ReActionView::Slots::FORMAT
       @response = ActionDispatch::Response.new
     end

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -14,7 +14,7 @@ def ask?(prompt = "")
   Readline.readline("===> #{prompt}? (y/N) ", true).squeeze(" ").strip == "y"
 end
 
-module SnapshotUtils # rubocop:disable Metrics/ModuleLength
+module SnapshotUtils
   def assert_compiled_snapshot(source, handler: ReActionView::Template::Handlers::ERB, virtual_path: "test", identifier: "test_template", format: :html, locals: [], options: {}) # rubocop:disable Metrics/ParameterLists,Layout/LineLength
     template = ActionView::Template.new(
       source,

--- a/test/snapshots/herb/template_handler_test/test_0035_instrumentation_stands_down_when_a_template_compiles_slots_compiled_6fe8ab80472fb91da8cbea4c9204061b.txt
+++ b/test/snapshots/herb/template_handler_test/test_0035_instrumentation_stands_down_when_a_template_compiles_slots_compiled_6fe8ab80472fb91da8cbea4c9204061b.txt
@@ -1,0 +1,3 @@
+ _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["test_template"] += 1) - 1 ; @output_buffer.safe_append='<!--herb-region:test_template:6fd3ef2b:'.freeze; @output_buffer.append=(_herb_occurrence); @output_buffer.safe_append='-->
+<p data-herb-slot="0:child">'.freeze; @output_buffer.append=(@name); @output_buffer.safe_append='</p><!--/herb-region:test_template-->'.freeze;
+@output_buffer

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -452,4 +452,17 @@ class Herb::TemplateHandlerTest < Minitest::Spec
 
     assert_includes compiled_source, %(data-herb-debug-file-full-path="/app/app/views/users/show.html.erb")
   end
+
+  test "instrumentation stands down when a template compiles slots" do
+    require "herb/engine/visitors/instrumentation_visitor"
+
+    previous = ReActionView.config.transform_visitors
+    ReActionView.config.transform_visitors = [::Herb::Engine::InstrumentationVisitor.new]
+
+    template = %(<%# herb:slots client %>\n<p><%= @name %></p>)
+
+    assert_compiled_snapshot(template, handler: ReActionView::Template::Handlers::Herb)
+  ensure
+    ReActionView.config.transform_visitors = previous
+  end
 end

--- a/test/template/handlers/schema_test.rb
+++ b/test/template/handlers/schema_test.rb
@@ -65,16 +65,14 @@ class ReActionView::SchemaTest < Minitest::Spec
     assert_equal :server, schema("<%# herb:slots server %>\n<p><%= @name %></p>").mode
   end
 
-  it "parks statics only in client mode" do
+  it "parks statics in server mode too, so a values response can unroll a branch" do
     source = "<% if @open %><b>yes</b><% else %><i>no</i><% end %>"
 
     refute_nil schema(source).statics
 
     ReActionView.config.slots = :server
 
-    server_statics = schema(source).statics
-
-    assert server_statics.nil? || server_statics.empty?
+    refute_empty schema(source).statics
   end
 
   it "carries the static markup" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,46 +180,46 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
-"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d2d24cf":
+"@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@1da6e95", "@herb-tools/browser@https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@1da6e9566":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d2d24cf#d9d168d7f646f605ebdda86449a05718c28e5f1e"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@1da6e9566#822c049ffae5b4466d7138ea20702ba1a55ff116"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e95"
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d2d24cf":
+"@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@1da6e95", "@herb-tools/client@https://pkg.pr.new/marcoroth/herb/@herb-tools/client@1da6e9566":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d2d24cf#62a6aea428e969c1d8a15ff0008a7a0ccb45ad88"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@1da6e9566#d0e3b761db05f756bdc7d746ad9239d3ab0e5a3a"
 
-"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf":
+"@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e95", "@herb-tools/core@https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e9566":
   version "0.10.3"
-  uid "42c1f99c434a405786199807507a06cab628c8ed"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf#42c1f99c434a405786199807507a06cab628c8ed"
+  uid "48bed2c6dc21f943214c5f7c78bd3c2b11bb1d84"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e9566#48bed2c6dc21f943214c5f7c78bd3c2b11bb1d84"
   dependencies:
     "@ruby/prism" "^1.9.0"
 
-"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d2d24cf":
+"@herb-tools/dev-tools@https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@1da6e9566":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@d2d24cf#f7c1d8aa5c5d13020a6a0476e27430c788e7e457"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/dev-tools@1da6e9566#afe58497c4b61df3ac93ae23a35d85f51f70762a"
   dependencies:
-    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@d2d24cf"
-    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@d2d24cf"
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
-    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d2d24cf"
+    "@herb-tools/browser" "https://pkg.pr.new/marcoroth/herb/@herb-tools/browser@1da6e95"
+    "@herb-tools/client" "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@1da6e95"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e95"
+    "@herb-tools/highlighter" "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@1da6e95"
 
-"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d2d24cf":
+"@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@1da6e95", "@herb-tools/highlighter@https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@1da6e9566":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@d2d24cf#7bd03ffb274dc710825b08fe91e86155c819f500"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/highlighter@1da6e9566#066359311ef2f18418c90cc8813b9616c23cae82"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
-    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d2d24cf"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e95"
+    "@herb-tools/node-wasm" "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@1da6e95"
     ansi_up "^6.0.6"
 
-"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d2d24cf":
+"@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@1da6e95", "@herb-tools/node-wasm@https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@1da6e9566":
   version "0.10.3"
-  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@d2d24cf#c68186cdb9e4b955d1319da6780e4fccbcb07e30"
+  resolved "https://pkg.pr.new/marcoroth/herb/@herb-tools/node-wasm@1da6e9566#ad9c6cd4d10bb2658436636c88162699c830b8e7"
   dependencies:
-    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@d2d24cf"
+    "@herb-tools/core" "https://pkg.pr.new/marcoroth/herb/@herb-tools/core@1da6e95"
     "@ruby/prism" "^1.9.0"
 
 "@iconify-json/logos@^1.2.4":


### PR DESCRIPTION
This pull request adds the server half of production slot refetching. 

When the Herb client materializes a conditional branch the server never rendered, it re-requests the values with its state in a `Herb-State` request header, and this header now steers the values program so it evaluates the client's branches.

`ReActionView::Slots::StateOverrides.parse` reads the header leniently. Anything blank, oversized past 8KB, malformed, or wrongly shaped degrades to nil and the compiled defaults serve the render, so a bad header can never break a response. `StateOverridesHelper#__herb_state_overrides` memoizes the parse per render and is included into Action View in the slots initializer, which is where the compiled values program finds it through its `defined?` check. Partials get the same overrides keyed by their own identifiers.

The helper is included into controllers too, with a friendlier reader on top, so an action can scope its own queries by what the client is showing. Values arrive uncoerced and client-controlled, so they deserve the same trust as params.

```ruby
def show
  @messages = Message.search(herb_state("q", ""))
end
```

Without a name, `herb_state` hands over the whole parse keyed by template identifier. With one, it answers the first template naming that state, or the default.

A steered slots response also answers with `Cache-Control: no-store`, since its body depends on a request header no cache key accounts for. Unsteered responses keep their caching.

Only the values program is steerable. The HTML render ignores overrides entirely, and a test pins that down.

A `Herb-Block` request header scopes the values program to one deferred block, so `<Async>` and `<Lazy>` fetches evaluate only the block they ask for. The header parses as leniently as `Herb-State`, and anything other than a plain integer falls back to the whole program.