### PR TITLE
Raise slot compile errors in development too

### DIFF
--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -183,7 +183,7 @@ module ReActionView
 
           return [] unless mode
 
-          [::Herb::Engine::Slots::Visitor.new(mode: mode, mark: mark, fatal: !::ReActionView.config.development?)]
+          [::Herb::Engine::Slots::Visitor.new(mode: mode, mark: mark)]
         end
 
         def layout_template?(template)

--- a/test/template/handlers/slots_test.rb
+++ b/test/template/handlers/slots_test.rb
@@ -91,4 +91,20 @@ class ReActionView::SlotsTest < Minitest::Spec
 
     assert_match(/slots must be/, error.message)
   end
+
+  test "a slot error raises at compile time in development too" do
+    source = <<~ERB
+      <%# herb:slots client %>
+      <%# herb:state (filter: "") %>
+      <% if Data.feed(filter).any? %>
+        <p>busy</p>
+      <% end %>
+    ERB
+
+    ReActionView.config.stub(:development?, true) do
+      error = assert_raises(Herb::Engine::CompilationError) { compile(source) }
+
+      assert_match(/cannot run Ruby to pick a branch/, error.message)
+    end
+  end
 end


### PR DESCRIPTION
This pull request makes a slot compile error raise in every environment, including development.

A slot error degrades the whole template on purpose. The visitor skips every marker, static and manifest, so a half-marked page never reaches the client. Since #127 that degrade was silent in development, on the theory that the rendered page is more useful than the exception. In practice the page looks fine and every interactive element on it is dead, the diagnostic only reaches the runtime session, and nothing in the browser says why. Building a demo page with `<% if Ops.feed(filter).any? %>` produced exactly that, a fully static page that took a `rails runner` compile probe to explain.

The exception is the better experience. Herb's compile error page shows the file and line, the diagnostic message, its suggestion, and the highlighted source excerpt, so the author fixes the template in seconds instead of debugging a page that quietly ignores clicks.