### PR TITLE
Give every gemfile the git-sourced Prism a git-sourced Herb needs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 
 gem "actionview", "~> 8.1"
 gem "appraisal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: 168298340a686806be16ea14c3dfdd0f8ec744f2
   branch: main
   specs:
     herb (0.10.3)
@@ -12,6 +12,13 @@ GIT
     herb (0.10.3-x86_64-darwin)
     herb (0.10.3-x86_64-linux-gnu)
     herb (0.10.3-x86_64-linux-musl)
+
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
 
 PATH
   remote: .
@@ -135,7 +142,6 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -222,6 +228,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties (~> 8.1)
   rake (~> 13.0)
   reactionview!
@@ -230,4 +237,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", "~> 7.0.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -13,6 +13,13 @@ GIT
     herb (0.10.3-x86_64-linux-gnu)
     herb (0.10.3-x86_64-linux-musl)
 
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
+
 PATH
   remote: ..
   specs:
@@ -125,7 +132,6 @@ GEM
       racc
     pretty_please (0.2.0)
       dispersion (~> 0.2)
-    prism (1.9.0)
     racc (1.8.1)
     rack (2.2.23)
     rack-test (2.2.0)
@@ -194,6 +200,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties (~> 7.0.0)
   rake (~> 13.0)
   reactionview!
@@ -202,4 +209,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", "~> 7.1.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -13,6 +13,13 @@ GIT
     herb (0.10.3-x86_64-linux-gnu)
     herb (0.10.3-x86_64-linux-musl)
 
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
+
 PATH
   remote: ..
   specs:
@@ -140,7 +147,6 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -226,6 +232,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties (~> 7.1.0)
   rake (~> 13.0)
   reactionview!
@@ -234,4 +241,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", "~> 7.2.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -13,6 +13,13 @@ GIT
     herb (0.10.3-x86_64-linux-gnu)
     herb (0.10.3-x86_64-linux-musl)
 
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
+
 PATH
   remote: ..
   specs:
@@ -139,7 +146,6 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -226,6 +232,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties (~> 7.2.0)
   rake (~> 13.0)
   reactionview!
@@ -234,4 +241,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", "~> 8.0.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -13,6 +13,13 @@ GIT
     herb (0.10.3-x86_64-linux-gnu)
     herb (0.10.3-x86_64-linux-musl)
 
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
+
 PATH
   remote: ..
   specs:
@@ -136,7 +143,6 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -223,6 +229,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties (~> 8.0.0)
   rake (~> 13.0)
   reactionview!
@@ -231,4 +238,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", "~> 8.1.0"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -13,6 +13,13 @@ GIT
     herb (0.10.3-x86_64-linux-gnu)
     herb (0.10.3-x86_64-linux-musl)
 
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
+
 PATH
   remote: ..
   specs:
@@ -135,7 +142,6 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    prism (1.9.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -222,6 +228,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties (~> 8.1.0)
   rake (~> 13.0)
   reactionview!
@@ -230,4 +237,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19

--- a/gemfiles/rails_8_2.gemfile
+++ b/gemfiles/rails_8_2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "herb", github: "marcoroth/herb", branch: "main"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", github: "rails/rails"
 gem "appraisal"
 gem "maxitest", "~> 7.0"

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -58,6 +58,13 @@ GIT
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
 
+GIT
+  remote: https://github.com/ruby/prism.git
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
+  specs:
+    prism (1.9.0)
+
 PATH
   remote: ..
   specs:
@@ -152,7 +159,6 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    prism (1.9.0)
     psych (5.4.0)
       date
       stringio
@@ -235,6 +241,7 @@ DEPENDENCIES
   maxitest (~> 7.0)
   minitest-difftastic
   minitest-mock
+  prism!
   railties!
   rake (~> 13.0)
   reactionview!
@@ -243,4 +250,4 @@ DEPENDENCIES
   tsort (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.1
+  4.0.19


### PR DESCRIPTION
This pull request fixes CI that has been red on main.

Herb installed from a git source refuses to build without a git-sourced Prism, since the released prism gem ships no C sources, and its extconf says exactly which line to add. None of the gemfiles declared one, so the requirement was only ever satisfied by a warm vendor cache. Any job that missed its cache failed during `bundle install`, which is how `rails_7_0` went red while its siblings stayed green on cached bundles.

The root `Gemfile` now pins the same prism tag Herb's own `Gemfile` uses, `bundle exec appraisal generate` carries it into every generated gemfile, and every lock gains the prism git source. The locks were resolved with a current Bundler because the one recorded in `BUNDLED WITH` crashes on the tagged git source, so that version moves along too.
