### PR TITLE
Run rewriting transforms after the slots visitor again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 168298340a686806be16ea14c3dfdd0f8ec744f2
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: 1da6e95664d77148c568024fe0e73f702e1928a5
+  revision: db16eadb9d5aa49db873449bda268af74786256b
   branch: main
   specs:
     herb (0.10.3)

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -60,7 +60,7 @@ module ReActionView
 
           slots = slot_visitors(template, source)
 
-          config[:visitors] = slots.any? ? [*visitors, *slots] : [*visitors, *rewriting_transform_visitors]
+          config[:visitors] = [*visitors, *slots, *rewriting_transform_visitors]
 
           erb_implementation.new(source, config).src
         end

--- a/test/snapshots/herb/template_handler_test/test_0035_instrumentation_runs_after_the_slots_visitor_and_keeps_its_markers_compiled_6fe8ab80472fb91da8cbea4c9204061b.txt
+++ b/test/snapshots/herb/template_handler_test/test_0035_instrumentation_runs_after_the_slots_visitor_and_keeps_its_markers_compiled_6fe8ab80472fb91da8cbea4c9204061b.txt
@@ -1,0 +1,3 @@
+ _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["test_template"] += 1) - 1 ; @output_buffer.safe_append='<!--herb-region:test_template:6fd3ef2b:'.freeze; @output_buffer.append=(_herb_occurrence); @output_buffer.safe_append='-->'.freeze; ::Herb::Engine::Runtime::Session.enter_render("test_template"); begin; @output_buffer.safe_append='
+<p data-herb-slot="0:child">'.freeze; @output_buffer.append=(::Herb::Engine::Runtime::Session.at("test_template", 2, 3, nil, end_line: 2, end_column: 15) { @name }); @output_buffer.safe_append='</p>'.freeze; ensure; ::Herb::Engine::Runtime::Session.leave_render; end; @output_buffer.safe_append='<!--/herb-region:test_template-->'.freeze;
+@output_buffer

--- a/test/snapshots/herb/template_handler_test/test_0035_instrumentation_stands_down_when_a_template_compiles_slots_compiled_6fe8ab80472fb91da8cbea4c9204061b.txt
+++ b/test/snapshots/herb/template_handler_test/test_0035_instrumentation_stands_down_when_a_template_compiles_slots_compiled_6fe8ab80472fb91da8cbea4c9204061b.txt
@@ -1,3 +1,0 @@
- _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["test_template"] += 1) - 1 ; @output_buffer.safe_append='<!--herb-region:test_template:6fd3ef2b:'.freeze; @output_buffer.append=(_herb_occurrence); @output_buffer.safe_append='-->
-<p data-herb-slot="0:child">'.freeze; @output_buffer.append=(@name); @output_buffer.safe_append='</p><!--/herb-region:test_template-->'.freeze;
-@output_buffer

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -453,7 +453,7 @@ class Herb::TemplateHandlerTest < Minitest::Spec
     assert_includes compiled_source, %(data-herb-debug-file-full-path="/app/app/views/users/show.html.erb")
   end
 
-  test "instrumentation stands down when a template compiles slots" do
+  test "instrumentation runs after the slots visitor and keeps its markers" do
     require "herb/engine/visitors/instrumentation_visitor"
 
     previous = ReActionView.config.transform_visitors


### PR DESCRIPTION
This pull request drops the workaround that kept rewriting transform visitors out of any template that compiles slots.

#143 had to partition `config.transform_visitors` and hand only the passive half to a slots template, because running `InstrumentationVisitor` after `Slots::Visitor`, the one order the visitor stack accepts, silently stripped every child anchor and value marker from the compiled page. marcoroth/herb#2582 fixes that in the engine. The compile now carries a `Replacements` record, a rewriter records each node it swaps out, and the slots visitor re-keys what it recorded before it inserts anything.

With that in place a slots template gets the full stack in the order the traits describe, validators and passive transforms first, then the slots visitor, then the rewriters. Instrumentation wraps every tag in a slots page the same way it wraps one in a plain page, and the markers stay put. The snapshot that used to prove instrumentation standing down now proves it running alongside the anchors.

The values, block and schema compiles keep the passive half only, as before. A rewriter would wrap the captured expressions there and add nothing anyone reads.

Depends on marcoroth/herb#2582.