### PR TITLE
Add `config.engine.parser_options` for every compile

### DIFF
--- a/lib/generators/reactionview/install_generator.rb
+++ b/lib/generators/reactionview/install_generator.rb
@@ -41,6 +41,9 @@ module ReActionView
 
             # Add visitors to the compile. Place them with `insert_before` and `insert_after`.
             # config.engine.visitors.use(Herb::Visitor.new)
+
+            # Parser options for every compile, merged over the ones in .herb.yml
+            # config.engine.parser_options = { strict_locals: true }
           end
         RUBY
       end

--- a/lib/reactionview/config.rb
+++ b/lib/reactionview/config.rb
@@ -51,9 +51,17 @@ module ReActionView
 
     class EngineOptions
       attr_reader :visitors
+      attr_reader :parser_options
 
       def initialize
         @visitors = ::Herb::Visitor::Stack.new
+        @parser_options = {}
+      end
+
+      def parser_options=(options)
+        raise ArgumentError, "parser_options must be a Hash of parser options, got #{options.inspect}" unless options.is_a?(Hash)
+
+        @parser_options = options.transform_keys(&:to_sym)
       end
     end
 

--- a/lib/reactionview/template/handlers/herb.rb
+++ b/lib/reactionview/template/handlers/herb.rb
@@ -54,6 +54,7 @@ module ReActionView
             filename: translate_path_for_editor(template.identifier),
             project_path: ::ReActionView.config.project_path,
             visitors: visitors,
+            **engine_options,
           }
 
           return values_source(template, source, config) if values_format?(template)
@@ -75,7 +76,8 @@ module ReActionView
             source,
             filename: translate_path_for_editor(path),
             project_path: ::ReActionView.config.project_path,
-            visitors: [*base_visitors(template), visitor]
+            visitors: [*base_visitors(template), visitor],
+            **engine_options
           ).src
 
           visitor
@@ -94,6 +96,7 @@ module ReActionView
             visitors: base_visitors(template),
             slot_visitor: visitor,
             block: index,
+            **engine_options,
             **VALUES_ESCAPING
           ).src
         end
@@ -107,7 +110,7 @@ module ReActionView
             mode: ::ReActionView.config.slot_mode_for(source),
             visitors: -> { base_visitors(template, validation_mode: schema_validation_mode) },
             engine: erb_implementation,
-            options: { project_path: ::ReActionView.config.project_path }
+            options: { project_path: ::ReActionView.config.project_path, **engine_options }
           )
         end
 
@@ -127,6 +130,16 @@ module ReActionView
           ]
 
           ::Herb::Visitor::Stack.arrange(visitors)
+        end
+
+        def engine_options
+          configured = ::ReActionView.config.engine.parser_options
+
+          return {} if configured.empty?
+
+          defaults = ::Herb.configuration.engine_option("parser_options", {})
+
+          { parser_options: defaults.transform_keys(&:to_sym).merge(configured) }
         end
 
         def rewrites_erb_source?(visitor)

--- a/test/reactionview/config_test.rb
+++ b/test/reactionview/config_test.rb
@@ -197,4 +197,21 @@ class ReActionView::ConfigTest < Minitest::Spec
 
     assert_same config.engine.visitors, read
   end
+
+  test "the engine parser options start empty" do
+    assert_empty ReActionView::Config.new.engine.parser_options
+  end
+
+  test "engine parser options take symbol keys whichever way they were written" do
+    config = ReActionView::Config.new
+    config.engine.parser_options = { "strict_locals" => true, prism_program: false }
+
+    assert_equal({ strict_locals: true, prism_program: false }, config.engine.parser_options)
+  end
+
+  test "engine parser options refuse anything but a Hash" do
+    error = assert_raises(ArgumentError) { ReActionView::Config.new.engine.parser_options = [:strict_locals] }
+
+    assert_match(/must be a Hash/, error.message)
+  end
 end

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -483,4 +483,79 @@ class Herb::TemplateHandlerTest < Minitest::Spec
   ensure
     ReActionView.config.engine.visitors.replace(previous)
   end
+
+  def compile_with_engine_parser_options(options)
+    previous = ReActionView.config.engine.parser_options
+    ReActionView.config.engine.parser_options = options
+
+    yield
+  ensure
+    ReActionView.config.engine.parser_options = previous
+  end
+
+  test "parser options on the engine reach the page compile" do
+    source = %(<%# herb:slots client %>\n<p><%= @name %></p>)
+    template_object = ActionView::Template.new(source, "/app/app/views/users/show.html.erb", ReActionView::Template::Handlers::Herb, virtual_path: "users/show", format: :html, locals: [])
+    implementation = ReActionView::Template::Handlers::Herb.erb_implementation
+    original = implementation.method(:new)
+    captured = nil
+
+    compile_with_engine_parser_options({ strict_locals: true }) do
+      implementation.stub(:new, lambda { |compiled, config = {}|
+        captured = config[:parser_options]
+        original.call(compiled, config)
+      }) do
+        Rails.stub(:root, Pathname.new("/app")) { ReActionView::Template::Handlers::Herb.call(template_object, source) }
+      end
+    end
+
+    assert_equal true, captured[:strict_locals]
+  end
+
+  test "parser options on the engine reach a block compile" do
+    source = %(<%# herb:slots client %>\n<Async><p><%= @name %></p><Fallback><p>wait</p></Fallback></Async>)
+    original = ::Herb::Engine::Slots::DynamicsCompiler.method(:new)
+    captured = nil
+
+    compile_with_engine_parser_options({ strict_locals: true }) do
+      ::Herb::Engine::Slots::DynamicsCompiler.stub(:new, lambda { |compiled, config = {}|
+        captured = config[:parser_options]
+        original.call(compiled, config)
+      }) do
+        Rails.stub(:root, Pathname.new("/app")) { ReActionView::Template::Handlers::Herb.compile_for_block(source, "/app/app/views/users/show.html.erb", 0) }
+      end
+    end
+
+    assert_equal true, captured[:strict_locals]
+  end
+
+  test "the project's parser options still apply when the engine has none" do
+    source = %(<%# herb:slots client %>\n<p><%= @name %></p>)
+    template_object = ActionView::Template.new(source, "/app/app/views/users/show.html.erb", ReActionView::Template::Handlers::Herb, virtual_path: "users/show", format: :html, locals: [])
+    implementation = ReActionView::Template::Handlers::Herb.erb_implementation
+    original = implementation.method(:new)
+    captured = :untouched
+
+    implementation.stub(:new, lambda { |compiled, config = {}|
+      captured = config.key?(:parser_options)
+      original.call(compiled, config)
+    }) do
+      Rails.stub(:root, Pathname.new("/app")) { ReActionView::Template::Handlers::Herb.call(template_object, source) }
+    end
+
+    assert_equal false, captured
+  end
+
+  test "a parser option on the engine that a visitor requires otherwise raises at compile" do
+    source = %(<%# herb:slots client %>\n<p><%= @name %></p>)
+    template_object = ActionView::Template.new(source, "/app/app/views/users/show.html.erb", ReActionView::Template::Handlers::Herb, virtual_path: "users/show", format: :html, locals: [])
+
+    error = compile_with_engine_parser_options({ track_locations: false }) do
+      assert_raises(ArgumentError) do
+        Rails.stub(:root, Pathname.new("/app")) { ReActionView::Template::Handlers::Herb.call(template_object, source) }
+      end
+    end
+
+    assert_equal "Herb::Engine::Validators::SecurityValidator requires the `track_locations` parser option to be true, but it is set to false", error.message
+  end
 end


### PR DESCRIPTION
Follow up on #159 which introduced `config.engine.visitors`, that gave an application a place for its visitors, and the visitors it adds declare the parser options they need themselves. 

What an application could not do was set a parser option of its own:

```ruby
ReActionView.configure do |config|
  config.engine.parser_options = { strict_locals: true }
end
```

`config.engine.parser_options` is the sibling of `visitors` on the engine options. The handler merges it over the project's parser options from `.herb.yml` and hands the result to every compile, page, values, block and schema alike, so the four never parse a template differently from one another. 

When nothing is configured the handler passes nothing and the engine keeps its defaults