### PR TITLE
Ship the client runtime as the `reactionview` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ bundle add reactionview
 rails generate reactionview:install
 ```
 
+The gem pins the `reactionview` client runtime for importmap applications and the generator imports it from `app/javascript/application.js`. With a bundler, install the npm package and import it from your entry point instead. See [JavaScript Client](https://reactionview.dev/javascript).
+
 ## Usage
 
 ReActionView provides two ways to use enhanced template processing:

--- a/docs/.vitepress/config/theme.mts
+++ b/docs/.vitepress/config/theme.mts
@@ -5,6 +5,7 @@ const defaultSidebar = [
     items: [
       { text: "Overview", link: "/overview" },
       { text: "Installation", link: "/installation" },
+      { text: "JavaScript Client", link: "/javascript" },
     ],
   },
   {

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -46,6 +46,10 @@ end
 ```
 :::
 
+## Add the JavaScript Client
+
+Interactive templates need the client runtime on the page. The gem pins it in the importmap for importmap applications, and the generator appends `import "reactionview"` to `app/javascript/application.js`. Applications with a bundler install the `reactionview` npm package instead. See [JavaScript Client](/javascript) for both setups.
+
 ## Configuration Options
 
 ### Basic Setup

--- a/docs/docs/javascript.md
+++ b/docs/docs/javascript.md
@@ -1,0 +1,68 @@
+# JavaScript Client <Badge type="info" text="^0.5.0" />
+
+Templates that declare states, slots, fragments or actions need the client runtime on the page. It indexes the markers the gem compiles into your HTML, keeps state, applies values the server sends back, and drives `data-herb-*` attributes.
+
+The runtime is [`@herb-tools/client`](https://github.com/marcoroth/herb/tree/main/javascript/packages/client). ReActionView ships it two ways so it matches the gem you have installed. The `reactionview` npm package bundles it for applications with a JavaScript bundler, and the gem carries the same build as an asset for applications on importmap.
+
+## Importmap
+
+The gem draws its own importmap, so `reactionview` is already pinned and preloaded in every application that uses importmap-rails. Import it from your entry point and you are done:
+
+:::code-group
+```js [app/javascript/application.js]
+import "reactionview"
+```
+:::
+
+The asset lives inside the gem, so there is nothing to install from npm and nothing to add to `config/importmap.rb`, and the runtime always matches the gem version. The gem's pins are drawn before your `config/importmap.rb`, so a pin of your own for `reactionview` wins if you ever need to point the name somewhere else.
+
+## Bundlers
+
+With jsbundling-rails, Vite or any other bundler, install the package and import it from your entry point:
+
+```bash
+yarn add reactionview
+```
+
+```js
+import "reactionview"
+```
+
+Keep the npm package on the same version as the gem. The compiled markers and the values payload are a contract between the two, and a mismatch is the first thing to check when a page stops reacting.
+
+## Starting with options
+
+Importing the package starts the runtime with `{ state: { debounce: 150 } }`, which delays server writes while the user is still typing. To choose the options yourself, call `Runtime.start` right after the import. The call has to happen synchronously in the same module, since the automatic start runs on the next microtask and yields to a runtime that is already up. Your options replace the defaults instead of merging with them.
+
+```js
+import { Runtime } from "reactionview"
+
+Runtime.start({ state: { debounce: 300 } })
+```
+
+`Runtime` is the `@herb-tools/client` class, so `Runtime.get()` returns the running instance with its `state`, `slots`, `outbox` and `actions`, the same object `window.HerbRuntime` points at.
+
+## Working with states from JavaScript
+
+Everything `@herb-tools/client` exports is available from `reactionview`, including `useState` for a Stimulus controller or any object with an `element`:
+
+```js
+import { Controller } from "@hotwired/stimulus"
+import { useState } from "reactionview"
+
+export default class extends Controller {
+  connect() {
+    this.state = useState(this)
+  }
+
+  draftChanged(value, previous) {
+    console.log(`draft went from ${previous} to ${value}`)
+  }
+}
+```
+
+`useState` reads the states declared around the element, calls a `<name>Changed` method on the host whenever one of them changes, and unsubscribes when the host disconnects. `stateFor(element)` does the reading alone when you do not need the callbacks.
+
+## Development tools
+
+The development tools are a separate script the gem injects into your layout when `config.debug_mode` is on. They attach to the runtime this page describes and never need to be imported yourself. See [Development Tools](/guides/development-tools).

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "yarn clean && tsc --emitDeclarationOnly && rolldown -c",
     "dev": "rolldown -c -w",
-    "clean": "rimraf dist && rimraf ../../../app/assets/"
+    "clean": "rimraf dist ../../../app/assets/javascripts/reactionview-dev-tools.*"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/javascript/packages/reactionview/README.md
+++ b/javascript/packages/reactionview/README.md
@@ -1,0 +1,21 @@
+# reactionview
+
+The ReActionView client runtime for Rails applications. This package bundles [`@herb-tools/client`](https://github.com/marcoroth/herb/tree/main/javascript/packages/client) into one self-contained module and starts it on import, so a page rendered by the `reactionview` gem becomes interactive with a single line.
+
+```js
+import "reactionview"
+```
+
+The same build ships inside the gem as `reactionview.esm.js`, and the gem draws its own importmap, so applications on importmap-rails get it without installing anything from npm. Applications with a JavaScript bundler install this package instead.
+
+The automatic start uses `{ state: { debounce: 150 } }`. To choose the options yourself, call `Runtime.start` right after the import. The call has to happen synchronously in the same module, before the automatic start gets its turn, and it replaces the defaults instead of merging with them.
+
+```js
+import { Runtime } from "reactionview"
+
+Runtime.start({ state: { debounce: 300 } })
+```
+
+Everything `@herb-tools/client` exports is re-exported here, including `useState` for wiring a controller or any other host object to the states around its element.
+
+See the [documentation](https://reactionview.dev/javascript) for the full setup.

--- a/javascript/packages/reactionview/package.json
+++ b/javascript/packages/reactionview/package.json
@@ -1,14 +1,47 @@
 {
   "name": "reactionview",
-  "version": "0.0.1",
-  "description": "ReActionView",
-  "main": "src/index.js",
+  "version": "0.4.0",
+  "description": "Reactive views for the HTML+ERB you already have. The browser runtime for ReActionView.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://reactionview.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/marcoroth/reactionview.git",
+    "url": "git+https://github.com/marcoroth/reactionview.git",
     "directory": "javascript/packages/reactionview"
   },
-  "author": "Marco Roth",
-  "license": "MIT",
-  "private": false
+  "main": "./dist/reactionview.esm.js",
+  "module": "./dist/reactionview.esm.js",
+  "sideEffects": [
+    "./src/auto-start.ts",
+    "./dist/reactionview.esm.js"
+  ],
+  "types": "./dist/types/index.d.ts",
+  "scripts": {
+    "build": "yarn clean && tsc --emitDeclarationOnly && rolldown -c",
+    "dev": "rolldown -c -w",
+    "clean": "rimraf dist ../../../app/assets/javascripts/reactionview.esm.js ../../../app/assets/javascripts/reactionview.esm.js.map"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/reactionview.esm.js",
+      "default": "./dist/reactionview.esm.js"
+    }
+  },
+  "dependencies": {
+    "@herb-tools/client": "https://pkg.pr.new/marcoroth/herb/@herb-tools/client@1da6e95"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "rolldown": "^1.2.3",
+    "typescript": "^7.0.2"
+  },
+  "files": [
+    "package.json",
+    "README.md",
+    "dist/",
+    "src/"
+  ]
 }

--- a/javascript/packages/reactionview/rolldown.config.js
+++ b/javascript/packages/reactionview/rolldown.config.js
@@ -5,12 +5,14 @@ export default [
       {
         file: "dist/reactionview.esm.js",
         format: "esm",
-        sourcemap: true
+        sourcemap: true,
+        minify: true
       },
       {
         file: "../../../app/assets/javascripts/reactionview.esm.js",
         format: "esm",
-        sourcemap: true
+        sourcemap: true,
+        minify: true
       },
     ],
     external: [],

--- a/javascript/packages/reactionview/rolldown.config.js
+++ b/javascript/packages/reactionview/rolldown.config.js
@@ -1,0 +1,19 @@
+export default [
+  {
+    input: "src/index.ts",
+    output: [
+      {
+        file: "dist/reactionview.esm.js",
+        format: "esm",
+        sourcemap: true
+      },
+      {
+        file: "../../../app/assets/javascripts/reactionview.esm.js",
+        format: "esm",
+        sourcemap: true
+      },
+    ],
+    external: [],
+    platform: "browser"
+  },
+]

--- a/javascript/packages/reactionview/src/auto-start.ts
+++ b/javascript/packages/reactionview/src/auto-start.ts
@@ -1,0 +1,9 @@
+import { Runtime } from "@herb-tools/client"
+
+if (typeof document !== "undefined") {
+  queueMicrotask(() => {
+    if (!Runtime.get() && !window.HerbRuntime) {
+      Runtime.start({ state: { debounce: 150 } })
+    }
+  })
+}

--- a/javascript/packages/reactionview/src/index.js
+++ b/javascript/packages/reactionview/src/index.js
@@ -1,1 +1,0 @@
-console.log("ReActionView")

--- a/javascript/packages/reactionview/src/index.ts
+++ b/javascript/packages/reactionview/src/index.ts
@@ -1,0 +1,5 @@
+import "./auto-start"
+
+export * from "@herb-tools/client"
+export { useState } from "@herb-tools/client/stimulus"
+export type { StateHost } from "@herb-tools/client/stimulus"

--- a/javascript/packages/reactionview/tsconfig.json
+++ b/javascript/packages/reactionview/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/lib/generators/reactionview/install_generator.rb
+++ b/lib/generators/reactionview/install_generator.rb
@@ -48,12 +48,39 @@ module ReActionView
         RUBY
       end
 
+      def add_javascript
+        if File.exist?("config/importmap.rb")
+          say "The gem pins the reactionview client runtime in your importmap, nothing to add there.", :green
+        elsif File.exist?("package.json")
+          say "Add the client runtime to your bundle: #{javascript_install_command}", :yellow
+        end
+
+        return unless File.exist?("app/javascript/application.js")
+
+        say "Importing reactionview in app/javascript/application.js...", :green
+
+        append_to_file "app/javascript/application.js", %(import "reactionview"\n)
+      end
+
+      def javascript_install_command
+        if File.exist?("bun.lock") || File.exist?("bun.lockb")
+          "bun add reactionview"
+        elsif File.exist?("pnpm-lock.yaml")
+          "pnpm add reactionview"
+        elsif File.exist?("package-lock.json")
+          "npm install reactionview"
+        else
+          "yarn add reactionview"
+        end
+      end
+
       def show_installation_complete
         say "\nReActionView has been successfully installed! 🎉", :green
         say "\nNext steps:", :blue
         say "  1. Review config/initializers/reactionview.rb"
         say "  2. Enable `config.intercept_erb = true` to process all `*.html.erb` templates using `Herb::Engine`."
         say "  3. Create `*.html.herb` templates for explicit Herb usage."
+        say "  4. Make sure `import \"reactionview\"` runs in your JavaScript entry point, see https://reactionview.dev/javascript"
 
         say "\nLearn more:", :yellow
         say "  GitHub:  https://github.com/marcoroth/reactionview"

--- a/lib/reactionview/asset_manifest.rb
+++ b/lib/reactionview/asset_manifest.rb
@@ -46,7 +46,7 @@ module ReActionView
 
     def explanation
       <<~MESSAGE
-        ReActionView's dev tools assets are missing from your precompiled assets.
+        ReActionView's JavaScript assets are missing from your precompiled assets.
         #{status}
 
         To fix this, delete the precompiled assets:

--- a/lib/reactionview/importmap.rb
+++ b/lib/reactionview/importmap.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+pin "reactionview", to: "reactionview.esm.js", preload: true

--- a/lib/reactionview/railtie.rb
+++ b/lib/reactionview/railtie.rb
@@ -10,17 +10,27 @@ module ReActionView
     # end
     #
     PRECOMPILE_ASSETS = %w[
+      reactionview.esm.js
       reactionview-dev-tools.esm.js
       reactionview-dev-tools.umd.js
     ].freeze
 
-    initializer "reactionview.assets", after: :load_config_initializers do |app|
-      if ReActionView.config.debug_mode_enabled? && app.config.respond_to?(:assets)
-        gem_root = Gem::Specification.find_by_name("reactionview").gem_dir
+    def self.gem_root
+      Gem::Specification.find_by_name("reactionview").gem_dir
+    end
 
-        app.config.assets.paths << File.join(gem_root, "app", "assets", "javascripts")
-        app.config.assets.precompile += PRECOMPILE_ASSETS
-      end
+    initializer "reactionview.assets", after: :load_config_initializers do |app|
+      next unless app.config.respond_to?(:assets)
+
+      app.config.assets.paths << File.join(ReActionView::Railtie.gem_root, "app", "assets", "javascripts")
+      app.config.assets.precompile += PRECOMPILE_ASSETS
+    end
+
+    initializer "reactionview.importmap", before: "importmap" do |app|
+      next unless app.config.respond_to?(:importmap)
+
+      app.config.importmap.paths << File.join(ReActionView::Railtie.gem_root, "lib", "reactionview", "importmap.rb")
+      app.config.importmap.cache_sweepers << File.join(ReActionView::Railtie.gem_root, "app", "assets", "javascripts")
     end
 
     initializer "reactionview.deprecator" do |app|

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "cd javascript/packages/dev-tools && npm run build",
+    "build": "cd javascript/packages/reactionview && npm run build && cd ../dev-tools && npm run build",
     "build:watch": "cd javascript/packages/dev-tools && npm run dev",
-    "clean": "rimraf app/assets/javascripts/reactionview-dev-tools.*",
+    "clean": "rimraf app/assets/javascripts/reactionview.esm.js* app/assets/javascripts/reactionview-dev-tools.*",
     "docs:dev": "cd docs && yarn dev",
     "docs:build": "cd docs && yarn build",
     "docs:preview": "cd docs && yarn preview"

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "tmpdir"
+require "rails/generators"
+require "rails/generators/test_case"
+require "generators/reactionview/install_generator"
+
+class ReActionView::InstallGeneratorTest < Rails::Generators::TestCase
+  tests ReActionView::Generators::InstallGenerator
+  destination File.join(Dir.tmpdir, "reactionview-install-generator")
+
+  setup do
+    prepare_destination
+  end
+
+  test "creates the initializer" do
+    run_generator
+
+    assert_file "config/initializers/reactionview.rb", /ReActionView.configure/
+  end
+
+  test "leaves the importmap alone and imports the client for an importmap application" do
+    Dir.chdir(destination_root) do
+      FileUtils.mkdir_p("config")
+      FileUtils.mkdir_p("app/javascript")
+      File.write("config/importmap.rb", %(pin "application"\n))
+      File.write("app/javascript/application.js", %(import "@hotwired/turbo-rails"\n))
+
+      run_generator
+    end
+
+    assert_file "config/importmap.rb", %(pin "application"\n)
+    assert_file "app/javascript/application.js", /import "reactionview"/
+  end
+
+  test "leaves a bundler application to its package manager" do
+    Dir.chdir(destination_root) do
+      FileUtils.mkdir_p("app/javascript")
+      File.write("package.json", "{}\n")
+      File.write("app/javascript/application.js", "")
+
+      output = run_generator
+
+      assert_match(/yarn add reactionview/, output)
+    end
+
+    assert_no_file "config/importmap.rb"
+    assert_file "app/javascript/application.js", /import "reactionview"/
+  end
+
+  test "names the package manager the application already uses" do
+    Dir.chdir(destination_root) do
+      FileUtils.mkdir_p("app/javascript")
+      File.write("package.json", "{}\n")
+      File.write("package-lock.json", "{}\n")
+      File.write("app/javascript/application.js", "")
+
+      assert_match(/npm install reactionview/, run_generator)
+    end
+  end
+end

--- a/test/reactionview/railtie_test.rb
+++ b/test/reactionview/railtie_test.rb
@@ -12,19 +12,34 @@ class ReActionView::RailtieTest < Minitest::Spec
     end
   end
 
+  class FakeImportmap
+    attr_accessor :paths, :cache_sweepers
+
+    def initialize
+      @paths = []
+      @cache_sweepers = []
+    end
+  end
+
   class FakeConfig
     attr_reader :assets
 
-    def initialize
+    def initialize(importmap: true)
       @assets = FakeAssets.new
+
+      return unless importmap
+
+      map = FakeImportmap.new
+
+      define_singleton_method(:importmap) { map }
     end
   end
 
   class FakeApp
     attr_reader :config
 
-    def initialize
-      @config = FakeConfig.new
+    def initialize(importmap: true)
+      @config = FakeConfig.new(importmap: importmap)
     end
   end
 
@@ -47,30 +62,29 @@ class ReActionView::RailtieTest < Minitest::Spec
     end
   end
 
+  def importmap_initializer
+    ReActionView::Railtie.initializers.find { |initializer| initializer.name == "reactionview.importmap" }
+  end
+
   def gem_javascripts_path
     File.join(Gem::Specification.find_by_name("reactionview").gem_dir, "app", "assets", "javascripts")
+  end
+
+  def gem_importmap_path
+    File.join(Gem::Specification.find_by_name("reactionview").gem_dir, "lib", "reactionview", "importmap.rb")
   end
 
   test "runs after config initializers so it can see the configured debug_mode" do
     assert_equal :load_config_initializers, assets_initializer.after
   end
 
-  test "installs assets outside development when debug mode is enabled" do
-    ReActionView.config.debug_mode = true
+  test "installs assets outside development when debug mode is disabled" do
+    ReActionView.config.debug_mode = false
 
     run_assets_initializer("production")
 
     assert_includes @app.config.assets.paths, gem_javascripts_path
     assert_equal ReActionView::Railtie::PRECOMPILE_ASSETS, @app.config.assets.precompile
-  end
-
-  test "does not install assets when debug mode is disabled" do
-    ReActionView.config.debug_mode = false
-
-    run_assets_initializer("production")
-
-    assert_empty @app.config.assets.paths
-    assert_empty @app.config.assets.precompile
   end
 
   test "installs assets in development when debug mode is left unset" do
@@ -81,11 +95,34 @@ class ReActionView::RailtieTest < Minitest::Spec
     assert_includes @app.config.assets.paths, gem_javascripts_path
   end
 
-  test "does not install assets outside development when debug mode is left unset" do
-    ReActionView.config.debug_mode = nil
+  test "draws its own importmap before the application's" do
+    assert_equal "importmap", importmap_initializer.before
 
-    run_assets_initializer("production")
+    importmap_initializer.run(@app)
 
-    assert_empty @app.config.assets.paths
+    assert_includes @app.config.importmap.paths, gem_importmap_path
+    assert_includes @app.config.importmap.cache_sweepers, gem_javascripts_path
+  end
+
+  test "stays out of the way without importmap-rails" do
+    app = FakeApp.new(importmap: false)
+
+    importmap_initializer.run(app)
+
+    refute_respond_to app.config, :importmap
+  end
+
+  test "pins the client runtime as a preloaded module" do
+    pins = []
+    drawer = Object.new
+    drawer.define_singleton_method(:pin) { |name, **options| pins << [name, options] }
+    drawer.instance_eval(File.read(gem_importmap_path), gem_importmap_path)
+
+    assert_equal [["reactionview", { to: "reactionview.esm.js", preload: true }]], pins
+  end
+
+  test "precompiles the client runtime alongside the dev tools" do
+    assert_includes ReActionView::Railtie::PRECOMPILE_ASSETS, "reactionview.esm.js"
+    assert_includes ReActionView::Railtie::PRECOMPILE_ASSETS, "reactionview-dev-tools.umd.js"
   end
 end


### PR DESCRIPTION
This pull request turns the placeholder `reactionview` npm package into the way applications get the client runtime, and ships the same build inside the gem for applications on importmap.

Reactive templates need `@herb-tools/client` on the page. Until now the only recipe was to install the npm package by hand from a pkg.pr.new pin and call `Runtime.start` yourself. An importmap application, which is what `rails new` produces, could not do that at all, so it could compile slots and never react to them.