### PR TITLE
Rescue Herb compile errors in the external template fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - "*-stable"
   pull_request:
     branches:
       - main
+      - "*-stable"
 
 jobs:
   assets:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -72,14 +72,14 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -68,14 +68,14 @@ GEM
       prism
     drb (2.2.3)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -76,14 +76,14 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -76,14 +76,14 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -73,14 +73,14 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -4,7 +4,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -72,14 +72,14 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -49,7 +49,7 @@ PATH
     reactionview (0.4.0)
       actionview (>= 7.0)
       cruise
-      herb (>= 0.10.0, < 0.11.0)
+      herb (>= 0.10.4, < 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -89,14 +89,14 @@ GEM
     drb (2.2.3)
     erb (6.0.7)
     erubi (1.13.1)
-    herb (0.10.3-aarch64-linux-gnu)
-    herb (0.10.3-aarch64-linux-musl)
-    herb (0.10.3-arm-linux-gnu)
-    herb (0.10.3-arm-linux-musl)
-    herb (0.10.3-arm64-darwin)
-    herb (0.10.3-x86_64-darwin)
-    herb (0.10.3-x86_64-linux-gnu)
-    herb (0.10.3-x86_64-linux-musl)
+    herb (0.10.4-aarch64-linux-gnu)
+    herb (0.10.4-aarch64-linux-musl)
+    herb (0.10.4-arm-linux-gnu)
+    herb (0.10.4-arm-linux-musl)
+    herb (0.10.4-arm64-darwin)
+    herb (0.10.4-x86_64-darwin)
+    herb (0.10.4-x86_64-linux-gnu)
+    herb (0.10.4-x86_64-linux-musl)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)

--- a/lib/reactionview/template/handlers/erb.rb
+++ b/lib/reactionview/template/handlers/erb.rb
@@ -14,7 +14,7 @@ module ReActionView
           ::ReActionView::Template::Handlers::Herb.call(
             template, source, validation_mode: herb_validation_mode(template)
           )
-        rescue StandardError => e
+        rescue ::Herb::Engine::CompilationError, StandardError => e
           raise unless fall_back_to_erb?(template)
 
           log_external_template_error(template, e)

--- a/reactionview.gemspec
+++ b/reactionview.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionview", ">= 7.0"
   spec.add_dependency "cruise"
-  spec.add_dependency "herb", ">= 0.10.0", "< 0.11.0"
+  spec.add_dependency "herb", ">= 0.10.4", "< 0.11.0"
 end


### PR DESCRIPTION
Herb v0.10.4 raises Herb::Engine::CompilationError as a SyntaxError, which a plain rescue StandardError no longer catches. The external template fallback now names the class explicitly, so a gem template that fails to compile through Herb keeps falling back to the stock ERB handler on both old and new Herb versions.