### PR TITLE
Rescue Herb compile errors in the external template fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - "*-stable"
   pull_request:
     branches:
       - main
+      - "*-stable"
 
 jobs:
   assets:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/marcoroth/herb.git
-  revision: b35fc937c6f71d3beb4621d9461b6cc061c9c411
+  revision: 82e214c45e43e01cc07734e0e41a5e2cb054eaa1
   branch: main
   specs:
     herb (0.10.3)

--- a/lib/reactionview/template/handlers/erb.rb
+++ b/lib/reactionview/template/handlers/erb.rb
@@ -16,7 +16,7 @@ module ReActionView
           ::ReActionView::Template::Handlers::Herb.call(
             template, source, validation_mode: herb_validation_mode(template)
           )
-        rescue StandardError => e
+        rescue ::Herb::Engine::CompilationError, StandardError => e
           raise unless fall_back_to_erb?(template)
 
           log_external_template_error(template, e)


### PR DESCRIPTION
Herb v0.10.4 raises Herb::Engine::CompilationError as a SyntaxError, which a plain rescue StandardError no longer catches. The external template fallback now names the class explicitly, so a gem template that fails to compile through Herb keeps falling back to the stock ERB handler on both old and new Herb versions.

This brings #163 into main for ReActionView v0.5.
