### PR TITLE
Compose with the Rails 8.2 built-in Herb implementation

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -71,6 +71,14 @@ end
 
 This gives you all the benefits of Herb's validation, security features, and debugging tools for your existing templates.
 
+### Rails 8.2 and the built-in Herb implementation
+
+Rails 8.2 compiles HTML templates through Herb on its own when an application runs the 8.2 framework defaults, through `config.action_view.html_erb_implementation`. That covers plain compilation. Enabling `intercept_erb` on Rails 8.2 adds what Rails does not do on its own. You get validators and transform visitors, validation modes, the debug tooling, and the external template modes for gem templates.
+
+The two settings compose. When `intercept_erb` is off, Rails 8.2 compiles your HTML templates through its built-in Herb implementation and ReActionView only handles `.html.herb` templates. When `intercept_erb` is on, ReActionView takes over HTML template compilation, and templates it declines, such as gem templates in `:skip` or `:fallback` mode, compile through the default ERB implementation instead of the built-in Herb one.
+
+On Rails 8.1 and earlier, `intercept_erb` remains the way to compile `.html.erb` templates through Herb at all.
+
 ### Advanced Configuration
 
 #### Custom Project Path for Editor Links <Badge type="info" text="^0.4.0" />

--- a/gemfiles/rails_8_2.gemfile.lock
+++ b/gemfiles/rails_8_2.gemfile.lock
@@ -15,7 +15,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 5ea765e5b00085a22f5cbe863c0d2ac765428242
+  revision: 52fa23ce8e1d39ff281bf300867e9ba7c7d66111
   specs:
     actionpack (8.2.0.alpha)
       actionview (= 8.2.0.alpha)
@@ -31,6 +31,7 @@ GIT
       activesupport (= 8.2.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.11)
+      herb (>= 0.10)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.7)
     activesupport (8.2.0.alpha)
@@ -113,7 +114,7 @@ GEM
     erubi (1.13.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -159,11 +160,11 @@ GEM
     pretty_please (0.2.0)
       dispersion (~> 0.2)
     prettyprint (0.2.0)
-    psych (5.4.0)
+    psych (5.5.0)
       date
       stringio
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -171,7 +172,7 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
-    ractor-dispatch (0.2.0)
+    ractor-dispatch (0.3.0)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -181,7 +182,7 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.2)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/reactionview/template/handlers/erb.rb
+++ b/lib/reactionview/template/handlers/erb.rb
@@ -11,6 +11,12 @@ module ReActionView
         autoload :Herb, "reactionview/template/handlers/herb/herb"
 
         def call(template, source)
+          if skip_external_template?(template)
+            @erb_fallback = true
+
+            return super
+          end
+
           return super unless intercept_template?(template)
 
           ::ReActionView::Template::Handlers::Herb.call(
@@ -21,10 +27,25 @@ module ReActionView
 
           log_external_template_error(template, e)
 
+          @erb_fallback = true
+
           super
         end
 
         private
+
+        def implementation_for(template)
+          return self.class.erb_implementation if @erb_fallback
+
+          super
+        end
+
+        def skip_external_template?(template)
+          return false unless INTERCEPTED_FORMATS.include?(template.format) && ReActionView.config.intercept_erb
+          return false if framework_template?(template) || local_template?(template)
+
+          ReActionView.config.external_template_mode == :skip
+        end
 
         def intercept_template?(template)
           return false unless INTERCEPTED_FORMATS.include?(template.format) && ReActionView.config.intercept_erb

--- a/lib/reactionview/template/handlers/herb/herb.rb
+++ b/lib/reactionview/template/handlers/herb/herb.rb
@@ -1,89 +1,101 @@
 # frozen_string_literal: true
 
 require "herb"
+require "herb/engine"
+
+begin
+  require "action_view/template/handlers/erb/herb"
+rescue LoadError
+  # Rails 8.1 and earlier ship no builtin Herb implementation
+end
 
 module ReActionView
   class Template
     module Handlers
       class Herb
-        class Herb < ::Herb::Engine
-          def initialize(input, properties = {})
-            @newline_pending = 0
-
-            # Dup properties so that we don't modify argument
-            properties = properties.to_h
-
-            properties[:bufvar]     ||= "@output_buffer"
-            properties[:preamble]   ||= ""
-            properties[:postamble]  ||= properties[:bufvar].to_s
-
-            # Tell Herb whether the template will be compiled with `frozen_string_literal: true`
-            properties[:freeze_template_literals] = !::ActionView::Template.frozen_string_literal
-
-            # Disable all Herb escape functions - let ActionView::OutputBuffer handle escaping
-            properties[:escapefunc] = ""
-            properties[:attrfunc] = nil
-            properties[:jsfunc] = nil
-            properties[:cssfunc] = nil
-
-            super
+        if defined?(::ActionView::Template::Handlers::ERB::Herb)
+          class Herb < ::ActionView::Template::Handlers::ERB::Herb
           end
+        else
+          class Herb < ::Herb::Engine
+            def initialize(input, properties = {})
+              @newline_pending = 0
 
-          private
+              # Dup properties so that we don't modify argument
+              properties = properties.to_h
 
-          def add_text(text)
-            return if text.empty?
+              properties[:bufvar]     ||= "@output_buffer"
+              properties[:preamble]   ||= ""
+              properties[:postamble]  ||= properties[:bufvar].to_s
 
-            if text == "\n"
-              @newline_pending += 1
-            else
-              with_buffer do
-                @src << ".safe_append='"
-                @src << ("\n" * @newline_pending) if @newline_pending.positive?
-                @src << text.gsub(/['\\]/, '\\\\\&') << @text_end
+              # Tell Herb whether the template will be compiled with `frozen_string_literal: true`
+              properties[:freeze_template_literals] = !::ActionView::Template.frozen_string_literal
+
+              # Disable all Herb escape functions - let ActionView::OutputBuffer handle escaping
+              properties[:escapefunc] = ""
+              properties[:attrfunc] = nil
+              properties[:jsfunc] = nil
+              properties[:cssfunc] = nil
+
+              super
+            end
+
+            private
+
+            def add_text(text)
+              return if text.empty?
+
+              if text == "\n"
+                @newline_pending += 1
+              else
+                with_buffer do
+                  @src << ".safe_append='"
+                  @src << ("\n" * @newline_pending) if @newline_pending.positive?
+                  @src << text.gsub(/['\\]/, '\\\\\&') << @text_end
+                end
+
+                @newline_pending = 0
               end
+            end
 
+            def add_expression(indicator, code)
+              flush_newline_if_pending(@src)
+
+              with_buffer do
+                @src << expression_append_method(indicator)
+
+                if expression_block?
+                  @src << " " << code
+                else
+                  @src << "(" << code << trailing_newline(code) << ")"
+                end
+              end
+            end
+
+            def expression_append_method(indicator)
+              if (indicator == "==") || @escape
+                ".safe_expr_append="
+              else
+                ".append="
+              end
+            end
+
+            def add_code(code)
+              flush_newline_if_pending(@src)
+              super
+            end
+
+            def add_postamble(_)
+              flush_newline_if_pending(@src)
+              super
+            end
+
+            def flush_newline_if_pending(src)
+              return unless @newline_pending.positive?
+
+              with_buffer { src << ".safe_append='#{"\n" * @newline_pending}" << @text_end }
               @newline_pending = 0
             end
-          end
-
-          def add_expression(indicator, code)
-            flush_newline_if_pending(@src)
-
-            with_buffer do
-              @src << expression_append_method(indicator)
-
-              if expression_block?
-                @src << " " << code
-              else
-                @src << "(" << code << trailing_newline(code) << ")"
-              end
-            end
-          end
-
-          def expression_append_method(indicator)
-            if (indicator == "==") || @escape
-              ".safe_expr_append="
-            else
-              ".append="
-            end
-          end
-
-          def add_code(code)
-            flush_newline_if_pending(@src)
-            super
-          end
-
-          def add_postamble(_)
-            flush_newline_if_pending(@src)
-            super
-          end
-
-          def flush_newline_if_pending(src)
-            return unless @newline_pending.positive?
-
-            with_buffer { src << ".safe_append='#{"\n" * @newline_pending}" << @text_end }
-            @newline_pending = 0
           end
         end
       end

--- a/test/template/handlers/external_template_mode_test.rb
+++ b/test/template/handlers/external_template_mode_test.rb
@@ -46,6 +46,40 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
     end
   end
 
+  def erubi_compile(source, identifier)
+    template = build(source, identifier)
+
+    without_builtin_herb do
+      ActionView::Template::Handlers::ERB.new.call(template, source)
+    end
+  end
+
+  def builtin_routing?
+    ActionView::Template::Handlers::ERB.respond_to?(:html_erb_implementation=)
+  end
+
+  def without_builtin_herb
+    return yield unless builtin_routing?
+
+    previous = ActionView::Template::Handlers::ERB.html_erb_implementation
+    ActionView::Template::Handlers::ERB.html_erb_implementation = nil
+
+    yield
+  ensure
+    ActionView::Template::Handlers::ERB.html_erb_implementation = previous if builtin_routing?
+  end
+
+  def with_builtin_herb
+    skip "Rails does not route HTML templates through a builtin Herb implementation" unless builtin_routing?
+
+    previous = ActionView::Template::Handlers::ERB.html_erb_implementation
+    ActionView::Template::Handlers::ERB.html_erb_implementation = ActionView::Template::Handlers::ERB::Herb
+
+    yield
+  ensure
+    ActionView::Template::Handlers::ERB.html_erb_implementation = previous if builtin_routing?
+  end
+
   test "defaults to :fallback" do
     assert_equal :fallback, ReActionView::Config.new.external_template_mode
   end
@@ -81,7 +115,7 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
 
     compiled = compile(VALID, EXTERNAL)
 
-    refute_equal ActionView::Template::Handlers::ERB.new.call(build(VALID, EXTERNAL), VALID), compiled
+    refute_equal erubi_compile(VALID, EXTERNAL), compiled
     assert_empty @log.string
   end
 
@@ -90,7 +124,7 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
 
     compiled = compile(INVALID, EXTERNAL)
 
-    assert_equal ActionView::Template::Handlers::ERB.new.call(build(INVALID, EXTERNAL), INVALID), compiled
+    assert_equal erubi_compile(INVALID, EXTERNAL), compiled
     assert_includes @log.string, "[ReActionView]"
     assert_includes @log.string, EXTERNAL
     assert_includes @log.string, "falling back to"
@@ -101,7 +135,7 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
 
     compiled = compile(VALID, EXTERNAL)
 
-    assert_equal ActionView::Template::Handlers::ERB.new.call(build(VALID, EXTERNAL), VALID), compiled
+    assert_equal erubi_compile(VALID, EXTERNAL), compiled
     assert_empty @log.string
   end
 
@@ -181,6 +215,28 @@ class ReActionView::ExternalTemplateModeTest < Minitest::Spec
     assert_empty @log.string
   ensure
     ReActionView.config.validation_mode = nil
+  end
+
+  test ":fallback falls back to the default ERB implementation when Rails routes HTML through Herb" do
+    with_builtin_herb do
+      ReActionView.config.external_template_mode = :fallback
+
+      compiled = compile(INVALID, EXTERNAL)
+
+      assert_equal erubi_compile(INVALID, EXTERNAL), compiled
+      assert_includes @log.string, "falling back to"
+    end
+  end
+
+  test ":skip compiles external templates with the default ERB implementation when Rails routes HTML through Herb" do
+    with_builtin_herb do
+      ReActionView.config.external_template_mode = :skip
+
+      compiled = compile(INVALID, EXTERNAL)
+
+      assert_equal erubi_compile(INVALID, EXTERNAL), compiled
+      assert_empty @log.string
+    end
   end
 
   test "external templates never render a validation overlay in :fallback mode" do

--- a/test/template/handlers/herb_test.rb
+++ b/test/template/handlers/herb_test.rb
@@ -558,4 +558,10 @@ class Herb::TemplateHandlerTest < Minitest::Spec
 
     assert_equal "Herb::Engine::Validators::SecurityValidator requires the `track_locations` parser option to be true, but it is set to false", error.message
   end
+
+  test "reuses the Rails builtin Herb implementation when available" do
+    skip "Rails ships no builtin Herb implementation" unless defined?(ActionView::Template::Handlers::ERB::Herb)
+
+    assert_operator ReActionView::Template::Handlers::Herb::Herb, :<, ActionView::Template::Handlers::ERB::Herb
+  end
 end


### PR DESCRIPTION
Rails 8.2 routes HTML templates through its own Herb implementation when an application runs the 8.2 framework defaults. 

The external template fallback and `:skip` mode reached the stock handler through super, which now compiles through Herb a second time, so templates the interceptor declined lost their permissive path. Both now force the default ERB implementation through `implementation_for`.

The engine subclass reuses `ActionView::Template::Handlers::ERB::Herb` when Rails ships it and keeps its own copy for Rails 8.1 and earlier.